### PR TITLE
v0.1.0-alpha: Initial feature set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ Thumbs.db
 *.swo
 *~
 
+# Claude Code
+.claude/
+
 # Environment
 .env
 .env.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,3 +53,5 @@ Everything runs inside a `window.addEventListener('load', ...)` closure in `inde
 
 ## Git Repo Conventions
 - add a commit including message for changes
+- work on feature branches, not directly on main
+- merge to main when features are tested and ready

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,5 +54,5 @@ Everything runs inside a `window.addEventListener('load', ...)` closure in `inde
 ## Git Repo Conventions
 - add a commit including message for changes
 - work on feature branches, not directly on main
-- merge to main when features are tested and ready
+- merge to main via pull requests only (main branch is protected)
 - when adding features or making changes, update both CLAUDE.md and README.md to reflect the current state

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Everything runs inside a `window.addEventListener('load', ...)` closure in `inde
 
 9. **Save & Load** — `saveModel()` wraps serialized scene with metadata and triggers `.woodmodel.json` download. `loadModel()` reads the file and calls `restoreScene()`.
 
-10. **Template Library** — Built-in metric templates array + custom templates stored in `localStorage`. Collapsible sidebar panel with filter/search.
+10. **Template Library** — Built-in metric templates + custom templates stored in `localStorage`. Integrated into toolbar add-piece dropdowns grouped by type.
 
 11. **Cut Joint Mode** — Two-click workflow: select target, then tool piece. Calls `csgSubtract` and records notch info in `userData.notches`.
 
@@ -55,3 +55,4 @@ Everything runs inside a `window.addEventListener('load', ...)` closure in `inde
 - add a commit including message for changes
 - work on feature branches, not directly on main
 - merge to main when features are tested and ready
+- when adding features or making changes, update both CLAUDE.md and README.md to reflect the current state

--- a/README.md
+++ b/README.md
@@ -9,21 +9,30 @@ A browser-based 3D woodworking modeller for planning and visualizing wooden cons
 - **5 shape types**: Board, Dowel, Wedge, L-Bracket, and Tapered Leg
 - **Interactive 3D viewport** with orbit controls (pan, rotate, zoom)
 - **Real-time editing** of dimensions, position, and rotation via the side panel
+- **Drag-to-move** pieces directly in the viewport (Shift+drag for vertical movement)
+- **Duplicate** selected piece via toolbar button or Ctrl+D
 - **CSG boolean subtraction** (Cut Joint) to carve joints and holes between pieces
 - **Snap mode** for aligning pieces to a 10mm grid
 - **Labels** displayed as 3D sprites above each piece
 - **Overlap detection** to highlight intersecting pieces
-- **Undo/Redo** support (including Ctrl+Z / Ctrl+Shift+Z)
-- **CSV export** of a cut list with dimensions, types, and notch counts
+- **Undo/Redo** support (Ctrl+Z / Ctrl+Shift+Z)
+- **Auto-resizing grid** that adapts to the size of your model
+- **Template library** with built-in metric woodworking parts and custom templates (stored in localStorage), integrated into toolbar dropdowns
+- **Save/Load** models as `.woodmodel.json` files for persistent projects
+- **Cost calculator** with per-piece pricing (fixed or per-mm), currency selector, and live cost summary
+- **CSV export** of a cut list with dimensions, types, notch counts, and costs
 
 ## Usage
 
 1. Open `index.html` in any modern browser
-2. Use the toolbar to add pieces (boards, dowels, wedges, etc.)
+2. Use the toolbar dropdowns to add pieces — choose from defaults or library templates
 3. Click a piece to select it and edit its dimensions, position, rotation, and label in the side panel
-4. Use **Cut Joint** to carve one piece into another (e.g., drill a dowel hole into a board)
-5. Use **Show Overlaps** to check for unintended intersections
-6. Export your cut list as CSV when done
+4. Drag pieces to reposition them (Shift+drag for vertical movement)
+5. Use **Cut Joint** to carve one piece into another (e.g., drill a dowel hole into a board)
+6. Use **Show Overlaps** to check for unintended intersections
+7. Set prices per piece and check the **Cost Summary** for budgeting
+8. **Save** your model and **Load** it later to continue working
+9. Export your cut list as CSV when done
 
 ## Tech Stack
 
@@ -34,4 +43,3 @@ A browser-based 3D woodworking modeller for planning and visualizing wooden cons
 ## License
 
 This project is licensed under the [MIT License](LICENSE).
-

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
     .add-dropdown > button { background: #3a3a3a; color: #ddd; border: 1px solid #555; border-radius: 4px; padding: 6px 10px; cursor: pointer; white-space: nowrap; font-size: 12px; }
     .add-dropdown > button:hover { background: #4a4a4a; }
     .add-dropdown > button::after { content: ' \25BC'; font-size: 8px; }
-    .add-menu { display: none; position: absolute; top: 100%; left: 0; min-width: 180px; background: #2a2a2a; border: 1px solid #555; border-radius: 4px; z-index: 300; padding: 4px 0; margin-top: 2px; box-shadow: 0 4px 12px rgba(0,0,0,0.4); }
+    .add-menu { display: none; position: fixed; min-width: 180px; background: #2a2a2a; border: 1px solid #555; border-radius: 4px; z-index: 300; padding: 4px 0; box-shadow: 0 4px 12px rgba(0,0,0,0.4); }
     .add-dropdown.open .add-menu { display: block; }
     .add-menu-item { display: flex; justify-content: space-between; padding: 5px 10px; cursor: pointer; font-size: 12px; color: #ddd; }
     .add-menu-item:hover { background: #4a4a4a; }
@@ -1913,6 +1913,12 @@ window.addEventListener('load', function() {
                 if (!wasOpen) {
                     buildDropdownMenu(dd);
                     dd.classList.add('open');
+                    // Position the fixed menu below the button
+                    var btn = dd.querySelector('button');
+                    var rect = btn.getBoundingClientRect();
+                    var menu = dd.querySelector('.add-menu');
+                    menu.style.top = rect.bottom + 2 + 'px';
+                    menu.style.left = rect.left + 'px';
                 }
             });
         })(dropdowns[di]);

--- a/index.html
+++ b/index.html
@@ -116,6 +116,7 @@
     <button id="btn-undo">Undo</button>
     <button id="btn-redo">Redo</button>
     <div class="separator"></div>
+    <button id="btn-duplicate">Duplicate</button>
     <button id="btn-delete">Delete</button>
     <button id="btn-clear">Clear All</button>
     <div class="separator"></div>
@@ -1547,6 +1548,46 @@ window.addEventListener('load', function() {
     // Delete & Clear
     // ============================================================
 
+    function duplicateSelected() {
+        if (!selectedPiece) return;
+        var ud = selectedPiece.userData;
+        var mesh;
+        if (ud.csgModified) {
+            // Clone raw geometry for CSG-modified pieces
+            var geo = selectedPiece.geometry.clone();
+            mesh = new THREE.Mesh(geo, createWoodMaterial());
+            mesh.castShadow = true;
+            mesh.receiveShadow = true;
+        } else {
+            if (ud.type === 'Board') mesh = makeBoard(ud.w, ud.h, ud.d);
+            else if (ud.type === 'Dowel') mesh = makeDowel(ud.r, ud.h);
+            else if (ud.type === 'Wedge') mesh = makeWedge(ud.w, ud.h, ud.d);
+            else if (ud.type === 'L-Bracket') mesh = makeLBracket(ud.w, ud.h, ud.d);
+            else if (ud.type === 'Tapered Leg') mesh = makeTaperedLeg(ud.rTop, ud.rBottom, ud.h);
+        }
+        // Copy transform with a small offset so it's visible
+        mesh.position.copy(selectedPiece.position);
+        mesh.position.x += 30;
+        mesh.position.z += 30;
+        mesh.rotation.copy(selectedPiece.rotation);
+        // Copy userData
+        mesh.userData.type = ud.type;
+        mesh.userData.id = ++pieceCounter;
+        mesh.userData.label = (ud.label || ud.type) + ' Copy';
+        mesh.userData.notches = ud.csgModified ? ud.notches : 0;
+        mesh.userData.csgModified = ud.csgModified || false;
+        mesh.userData.price = ud.price || 0;
+        mesh.userData.priceMode = ud.priceMode || 'fixed';
+        if (ud.type === 'Board' || ud.type === 'Wedge' || ud.type === 'L-Bracket') {
+            mesh.userData.w = ud.w; mesh.userData.h = ud.h; mesh.userData.d = ud.d;
+        } else if (ud.type === 'Dowel') {
+            mesh.userData.r = ud.r; mesh.userData.h = ud.h;
+        } else if (ud.type === 'Tapered Leg') {
+            mesh.userData.rTop = ud.rTop; mesh.userData.rBottom = ud.rBottom; mesh.userData.h = ud.h;
+        }
+        addPiece(mesh);
+    }
+
     function deleteSelected() {
         if (!selectedPiece) return;
         pushUndo();
@@ -1960,6 +2001,7 @@ window.addEventListener('load', function() {
 
     document.getElementById('btn-undo').addEventListener('click', undo);
     document.getElementById('btn-redo').addEventListener('click', redo);
+    document.getElementById('btn-duplicate').addEventListener('click', duplicateSelected);
     document.getElementById('btn-delete').addEventListener('click', deleteSelected);
     document.getElementById('btn-clear').addEventListener('click', clearAll);
     document.getElementById('btn-export').addEventListener('click', exportCSV);
@@ -1988,6 +2030,9 @@ window.addEventListener('load', function() {
         } else if (e.ctrlKey && e.key === 'Z' && e.shiftKey) {
             e.preventDefault();
             redo();
+        } else if (e.ctrlKey && e.key === 'd') {
+            e.preventDefault();
+            duplicateSelected();
         } else if (e.key === 'Delete' && document.activeElement.tagName !== 'INPUT' && document.activeElement.tagName !== 'TEXTAREA') {
             deleteSelected();
         }


### PR DESCRIPTION
## Summary
- Save/Load models as .woodmodel.json
- Template library integrated into toolbar dropdowns (built-in metric parts + custom templates)
- Cost calculator with per-piece pricing, currency selector, CSV export
- Duplicate selected piece (button + Ctrl+D)
- Auto-resizing grid
- Fix: CSG boolean subtraction (missing a.invert())
- Fix: drag selecting wrong piece when overlapping
- Fix: Delete key deleting pieces while editing input fields
- Replace imperial templates with metric dimensions
- Remove nested scrollbar from template list
- Fix dropdown menus clipped by toolbar overflow
- Branch protection and PR workflow conventions

## Test plan
- [ ] Open index.html, add pieces from toolbar dropdowns (default + templates)
- [ ] Drag pieces, duplicate with Ctrl+D
- [ ] Save model, clear all, load model back
- [ ] Set prices, verify cost summary and CSV export
- [ ] Cut Joint between two pieces
- [ ] Undo/Redo through operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)