### PR TITLE
feat: add auto-release GitHub Actions workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,78 @@
+name: Auto Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get latest tag
+        id: latest_tag
+        run: |
+          latest=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          echo "tag=${latest:-v0.0.0}" >> $GITHUB_OUTPUT
+
+      - name: Determine version bump from commits
+        id: bump
+        run: |
+          latest="${{ steps.latest_tag.outputs.tag }}"
+          if git rev-parse "$latest" >/dev/null 2>&1; then
+            commits=$(git log "$latest"..HEAD --pretty=format:"%s")
+          else
+            commits=$(git log --pretty=format:"%s")
+          fi
+          if [ -z "$commits" ]; then
+            echo "bump=none" >> $GITHUB_OUTPUT
+          elif echo "$commits" | grep -qE "^.+!:|BREAKING CHANGE"; then
+            echo "bump=major" >> $GITHUB_OUTPUT
+          elif echo "$commits" | grep -qE "^feat(\(.+\))?:"; then
+            echo "bump=minor" >> $GITHUB_OUTPUT
+          else
+            echo "bump=patch" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Calculate new version
+        id: version
+        if: steps.bump.outputs.bump != 'none'
+        run: |
+          version="${{ steps.latest_tag.outputs.tag }}"
+          version="${version#v}"
+          version="${version%%-*}"
+          IFS='.' read -r major minor patch <<< "$version"
+          major=${major:-0}; minor=${minor:-0}; patch=${patch:-0}
+          case "${{ steps.bump.outputs.bump }}" in
+            major) major=$((major+1)); minor=0; patch=0 ;;
+            minor) minor=$((minor+1)); patch=0 ;;
+            patch) patch=$((patch+1)) ;;
+          esac
+          echo "tag=v${major}.${minor}.${patch}" >> $GITHUB_OUTPUT
+
+      - name: Generate release notes
+        if: steps.bump.outputs.bump != 'none'
+        run: |
+          latest="${{ steps.latest_tag.outputs.tag }}"
+          if git rev-parse "$latest" >/dev/null 2>&1; then
+            git log "$latest"..HEAD --pretty=format:"- %s" \
+              | grep -v "^- Merge" > release_notes.txt
+          else
+            git log --pretty=format:"- %s" \
+              | grep -v "^- Merge" > release_notes.txt
+          fi
+
+      - name: Create GitHub Release
+        if: steps.bump.outputs.bump != 'none'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "${{ steps.version.outputs.tag }}" \
+            --notes-file release_notes.txt


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/auto-release.yml` triggered on every push to `main`
- Reads commits since the last tag and bumps the version automatically:
  - `fix:` / `refactor:` / `docs:` → patch (0.0.x)
  - `feat:` → minor (0.x.0)
  - `!` / `BREAKING CHANGE` → major (x.0.0)
- Skips release creation if there are no new commits
- Release notes are generated from commit messages (merge commits excluded)

## Test plan

- [ ] Merge this PR and verify the workflow triggers on GitHub Actions
- [ ] Confirm a new patch release (v0.2.1) is created automatically, covering the fix commits from PR #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)