### PR TITLE
feat: add object grouping via THREE.Group

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,12 @@ Everything runs inside a `window.addEventListener('load', ...)` closure in `inde
 
 13. **Overlap Detection** — Bounding-box intersection checks between all piece pairs.
 
+    **X-Ray Mode** — `xrayMode` toggle makes all non-selected pieces translucent (`opacity = XRAY_OPACITY`, `depthWrite = false`) so pieces hidden inside others (e.g. dowels in boards) become visible. The currently selected piece stays fully opaque. `applyXray(mesh)` is called whenever a mesh enters the scene (addPiece, restoreScene, split) or when selection changes.
+
+    **Grouping** — `THREE.Group` is used as the container (no reimplementation). Toolbar Group/Ungroup buttons. Multi-select via Ctrl+click (builds `multiSelected` Set); `createGroup()` centers a new Group, reparents the selected pieces as children, and assigns `userData.groupId` to each. `ungroup()` reparents children back to the scene preserving world transforms. Clicking any piece in a group selects the whole group; dragging moves the group as a unit. Snap (`faceSnapXZ`/`faceSnapY`) excludes the dragged group's own children and force-updates descendant matrices so Box3 checks are correct. Snap indicator only flashes on the no-snap → snap transition. `splitSelected` and `duplicateSelected` use world transforms so operations on grouped pieces keep positions correct; split parts re-attach to the same group. `serializeScene`/`restoreScene` persist `groups[]` (gId + transform) alongside `groupId` on each piece; `restoreMesh` always sets `userData.type` so CSG-modified pieces survive load/save cycles.
+
+    **Template Export/Import** — Custom templates (in `localStorage`) can be exported to a `.woodtemplates.json` file and imported back; used for sharing template libraries between installations.
+
 14. **Cost Calculator** — Per-piece `userData.price` and `userData.priceMode` (fixed/per_mm). `updateCostSummary()` renders live totals in sidebar; grouped (split) pieces show their source board cost once under a group header. `exportCSV()` includes a `sourceGroup` column. Currency persisted in `localStorage`.
 
 15. **Mouse/Keyboard Interaction** — Raycasting for piece selection, drag-move (with snap support), keyboard shortcuts. Delete key is suppressed when an input is focused.

--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ A browser-based 3D woodworking modeller for planning and visualizing wooden cons
 - **Duplicate** selected piece via toolbar button or Ctrl+D
 - **Split** a board or dowel — either by number of parts (equal-length) or by target part length (max pieces that fit, with optional leftover kept as extra piece) — with configurable saw kerf (blade thickness) so material lost to each cut is accounted for; split parts are visually grouped in the object list and cost summary (one board purchase = one cost entry)
 - **CSG boolean subtraction** (Cut Joint) to carve joints and holes between pieces
-- **Snap mode** for aligning pieces to a 10mm grid
+- **Snap mode** with face-to-face contact, coplanar edge alignment, and dowel center-axis snapping; falls back to a 10mm grid
+- **X-Ray mode** to see through pieces and locate objects inside others (e.g. dowels)
+- **Grouping** — Ctrl+click to multi-select, then Group/Ungroup from the toolbar; groups move and snap as a unit and persist in save files
 - **Labels** displayed as 3D sprites above each piece
 - **Overlap detection** to highlight intersecting pieces
 - **Undo/Redo** support (Ctrl+Z / Ctrl+Shift+Z)
 - **Auto-resizing grid** that adapts to the size of your model
-- **Template library** with built-in metric woodworking parts and custom templates (stored in localStorage), integrated into toolbar dropdowns
+- **Template library** with built-in metric woodworking parts and custom templates (stored in localStorage), integrated into toolbar dropdowns; custom templates can be exported/imported as JSON
 - **Save/Load** models as `.woodmodel.json` files for persistent projects
 - **Cost calculator** with per-piece pricing (fixed or per-mm), currency selector, and live cost summary
 - **CSV export** of a cut list with dimensions, types, notch counts, and costs

--- a/index.html
+++ b/index.html
@@ -128,6 +128,14 @@
     .modal-buttons button.primary { background: #c8934a; color: #1a1a1a; border-color: #e8a030; }
     .modal-buttons button.primary:hover { background: #e8a030; }
     .modal-buttons button.primary:disabled { background: #555; color: #888; border-color: #555; cursor: not-allowed; }
+    #group-panel { margin-top: 8px; padding-top: 8px; border-top: 1px solid #555; }
+    #group-panel h3 { margin: 0 0 6px; color: #c8934a; font-size: 13px; }
+    #group-member-info { font-size: 11px; color: #888; margin-bottom: 6px; }
+    #btn-ungroup { width: 100%; background: #3a3a3a; color: #ddd; border: 1px solid #555; border-radius: 3px; padding: 4px 8px; cursor: pointer; font-size: 12px; margin-top: 6px; }
+    #btn-ungroup:hover { background: #4a4a4a; }
+    .obj-list-item.multi-selected { background: #224488; color: #aad; }
+    .obj-list-item.group-member { padding-left: 20px; border-left: 2px solid #4499ff; }
+    .obj-group-scene-header { padding: 3px 8px; font-size: 11px; font-weight: bold; background: #182030; color: #4499ff; border-bottom: 1px solid #555; border-top: 1px solid #555; }
 </style>
 </head>
 <body>
@@ -151,6 +159,7 @@
     <button id="btn-redo" data-i18n="toolbar.redo">Redo</button>
     <div class="separator"></div>
     <button id="btn-duplicate" data-i18n="toolbar.duplicate">Duplicate</button>
+    <button id="btn-group" data-i18n="toolbar.group" disabled>Group</button>
     <button id="btn-delete" data-i18n="toolbar.delete">Delete</button>
     <button id="btn-clear" data-i18n="toolbar.clearAll">Clear All</button>
     <div class="separator"></div>
@@ -255,6 +264,17 @@
         <div id="size-summary"></div>
     </div>
 
+    <div id="group-panel" style="display:none">
+        <h3 data-i18n="panel.group.title">Group</h3>
+        <div id="group-member-info"></div>
+        <div class="input-row">
+            <div><label data-i18n="panel.pos.x">X</label><input type="number" id="grp-pos-x" step="1"></div>
+            <div><label data-i18n="panel.pos.y">Y</label><input type="number" id="grp-pos-y" step="1"></div>
+            <div><label data-i18n="panel.pos.z">Z</label><input type="number" id="grp-pos-z" step="1"></div>
+        </div>
+        <button id="btn-ungroup" data-i18n="panel.group.ungroup">Ungroup</button>
+    </div>
+
     <button id="btn-save-template" data-i18n="panel.saveAsTemplate">Save as Template</button>
     <div id="template-io">
         <button id="btn-export-templates" data-i18n="toolbar.exportTemplates">Export Templates</button>
@@ -340,6 +360,7 @@ window.addEventListener('load', function() {
             'toolbar.undo': 'Undo',
             'toolbar.redo': 'Redo',
             'toolbar.duplicate': 'Duplicate',
+            'toolbar.group': 'Group',
             'toolbar.delete': 'Delete',
             'toolbar.clearAll': 'Clear All',
             'toolbar.exportCsv': 'Export CSV',
@@ -352,6 +373,10 @@ window.addEventListener('load', function() {
             'snap.indicator': 'Snapped!',
             'panel.objects': 'Objects',
             'panel.noSelection': 'No piece selected',
+            'panel.group.title': 'Group',
+            'panel.group.members': '{n} object(s)',
+            'panel.group.ungroup': 'Ungroup',
+            'panel.group.hint': 'Ctrl+click to multi-select, then Group',
             'panel.dimensions': 'Dimensions (mm)',
             'panel.position': 'Position (mm)',
             'panel.rotation': 'Rotation (degrees)',
@@ -473,6 +498,7 @@ window.addEventListener('load', function() {
             'toolbar.undo': 'Rückgängig',
             'toolbar.redo': 'Wiederholen',
             'toolbar.duplicate': 'Duplizieren',
+            'toolbar.group': 'Gruppieren',
             'toolbar.delete': 'Löschen',
             'toolbar.clearAll': 'Alles löschen',
             'toolbar.exportCsv': 'CSV-Export',
@@ -485,6 +511,10 @@ window.addEventListener('load', function() {
             'snap.indicator': 'Eingerastet!',
             'panel.objects': 'Objekte',
             'panel.noSelection': 'Kein Teil ausgewählt',
+            'panel.group.title': 'Gruppe',
+            'panel.group.members': '{n} Objekt(e)',
+            'panel.group.ungroup': 'Gruppierung aufheben',
+            'panel.group.hint': 'Strg+Klick für Mehrfachauswahl, dann Gruppieren',
             'panel.dimensions': 'Maße (mm)',
             'panel.position': 'Position (mm)',
             'panel.rotation': 'Drehung (Grad)',
@@ -1057,6 +1087,11 @@ window.addEventListener('load', function() {
     var cutTarget = null;
     var overlapMode = false;
     var overlapHighlighted = [];
+    var groups = [];
+    var groupCounter = 0;
+    var selectedGroup = null;
+    var multiSelected = new Set();
+    var MULTI_SELECT_COLOR = 0x4499ff;
 
     // Undo/Redo
     var undoStack = [];
@@ -1179,11 +1214,14 @@ window.addEventListener('load', function() {
     }
 
     function applyXray(mesh) {
-        var isSelected = xrayMode && mesh === selectedPiece;
-        mesh.material.transparent = xrayMode && !isSelected;
-        mesh.material.opacity = (xrayMode && !isSelected) ? XRAY_OPACITY : 1.0;
+        var isActive = xrayMode && (
+            mesh === selectedPiece ||
+            (selectedGroup && mesh.userData.groupId === selectedGroup.userData.gId)
+        );
+        mesh.material.transparent = xrayMode && !isActive;
+        mesh.material.opacity = (xrayMode && !isActive) ? XRAY_OPACITY : 1.0;
         // Disable depth writes so transparent pieces don't occlude objects inside them
-        mesh.material.depthWrite = !xrayMode || isSelected;
+        mesh.material.depthWrite = !xrayMode || isActive;
     }
 
     function addPiece(mesh) {
@@ -1194,6 +1232,156 @@ window.addEventListener('load', function() {
         applyXray(mesh);
         selectPiece(mesh);
         updateGrid();
+    }
+
+    // ============================================================
+    // Grouping (THREE.Group)
+    // ============================================================
+
+    function findGroupById(gId) {
+        for (var i = 0; i < groups.length; i++) {
+            if (groups[i].userData.gId === gId) return groups[i];
+        }
+        return null;
+    }
+
+    function updateGroupButton() {
+        var btn = document.getElementById('btn-group');
+        if (btn) btn.disabled = multiSelected.size < 2;
+    }
+
+    function selectGroup(group) {
+        // Deselect any current piece/group first
+        if (selectedPiece) {
+            selectedPiece.material.color.setHex(WOOD_COLOR);
+            selectedPiece = null;
+        }
+        if (selectedGroup && selectedGroup !== group) {
+            selectedGroup.children.forEach(function(c) { if (c.material) c.material.color.setHex(WOOD_COLOR); });
+        }
+        multiSelected.forEach(function(m) { m.material.color.setHex(WOOD_COLOR); });
+        multiSelected.clear();
+        clearOverlaps();
+
+        selectedGroup = group;
+        group.children.forEach(function(c) { if (c.material) c.material.color.setHex(SELECT_COLOR); });
+
+        // Hide piece panels
+        noSelection.style.display = 'none';
+        dimFields.style.display = 'none';
+        posFields.style.display = 'none';
+        rotFields.style.display = 'none';
+        document.getElementById('rot-buttons').style.display = 'none';
+        labelField.style.display = 'none';
+        priceField.style.display = 'none';
+        summarySection.style.display = 'none';
+        btnSaveTemplate.style.display = 'none';
+
+        // Show group panel
+        document.getElementById('group-panel').style.display = 'block';
+        document.getElementById('grp-pos-x').value = Math.round(group.position.x);
+        document.getElementById('grp-pos-y').value = Math.round(group.position.y);
+        document.getElementById('grp-pos-z').value = Math.round(group.position.z);
+        document.getElementById('group-member-info').textContent =
+            t('panel.group.members', { n: group.children.length });
+
+        updateGroupButton();
+        if (xrayMode) pieces.forEach(applyXray);
+        updateObjectList();
+        updateCostSummary();
+    }
+
+    function deselectGroup() {
+        if (!selectedGroup) return;
+        selectedGroup.children.forEach(function(c) { if (c.material) c.material.color.setHex(WOOD_COLOR); });
+        selectedGroup = null;
+        document.getElementById('group-panel').style.display = 'none';
+        if (xrayMode) pieces.forEach(applyXray);
+    }
+
+    function toggleMultiSelect(mesh) {
+        // Can't multi-select pieces that are already in a group
+        if (mesh.userData.groupId) return;
+        // Clear single selection and group selection
+        if (selectedPiece) { selectedPiece.material.color.setHex(WOOD_COLOR); selectedPiece = null; }
+        if (selectedGroup) deselectGroup();
+
+        if (multiSelected.has(mesh)) {
+            multiSelected.delete(mesh);
+            mesh.material.color.setHex(WOOD_COLOR);
+        } else {
+            multiSelected.add(mesh);
+            mesh.material.color.setHex(MULTI_SELECT_COLOR);
+        }
+        updateGroupButton();
+        // Hide piece panels while in multi-select mode
+        noSelection.style.display = multiSelected.size === 0 ? 'block' : 'none';
+        dimFields.style.display = 'none';
+        posFields.style.display = 'none';
+        rotFields.style.display = 'none';
+        document.getElementById('rot-buttons').style.display = 'none';
+        labelField.style.display = 'none';
+        priceField.style.display = 'none';
+        summarySection.style.display = 'none';
+        btnSaveTemplate.style.display = 'none';
+        document.getElementById('group-panel').style.display = 'none';
+    }
+
+    function createGroup() {
+        if (multiSelected.size < 2) return;
+        pushUndo();
+        var meshArray = Array.from(multiSelected);
+
+        var center = new THREE.Vector3();
+        meshArray.forEach(function(m) { center.add(m.position); });
+        center.divideScalar(meshArray.length);
+
+        var gId = 'grp_' + (++groupCounter);
+        var group = new THREE.Group();
+        group.userData.gId = gId;
+        group.position.copy(center);
+        scene.add(group);
+        groups.push(group);
+
+        meshArray.forEach(function(m) {
+            scene.remove(m);
+            m.position.sub(center);
+            m.userData.groupId = gId;
+            group.add(m);
+            removeLabel(m);
+        });
+
+        multiSelected.clear();
+        updateGroupButton();
+        selectGroup(group);
+        updateGrid();
+    }
+
+    function ungroup() {
+        if (!selectedGroup) return;
+        pushUndo();
+        var group = selectedGroup;
+        var children = group.children.slice();
+
+        children.forEach(function(m) {
+            var worldPos = new THREE.Vector3();
+            m.getWorldPosition(worldPos);
+            group.remove(m);
+            m.position.copy(worldPos);
+            m.userData.groupId = null;
+            scene.add(m);
+            if (labelsVisible) createLabel(m);
+            applyXray(m);
+        });
+
+        scene.remove(group);
+        var idx = groups.indexOf(group);
+        if (idx !== -1) groups.splice(idx, 1);
+
+        deselectGroup();
+        selectPiece(null);
+        updateGrid();
+        updateObjectList();
     }
 
     // ============================================================
@@ -1301,6 +1489,16 @@ window.addEventListener('load', function() {
 
     function selectPiece(mesh) {
         clearOverlaps();
+        // Deselect group if switching to a piece or clearing selection
+        if (selectedGroup) {
+            selectedGroup.children.forEach(function(c) { if (c.material) c.material.color.setHex(WOOD_COLOR); });
+            selectedGroup = null;
+            document.getElementById('group-panel').style.display = 'none';
+        }
+        // Clear multi-select highlights
+        multiSelected.forEach(function(m) { m.material.color.setHex(WOOD_COLOR); });
+        multiSelected.clear();
+        updateGroupButton();
         if (selectedPiece && selectedPiece !== mesh) {
             selectedPiece.material.color.setHex(WOOD_COLOR);
         }
@@ -1555,6 +1753,8 @@ window.addEventListener('load', function() {
     function faceSnapXZ(mesh, xVal, zVal) {
         mesh.position.x = xVal;
         mesh.position.z = zVal;
+        // Force-update descendants so Group bounding boxes reflect the new position
+        mesh.updateMatrixWorld(true);
         var box = new THREE.Box3().setFromObject(mesh);
         var rOff = box.max.x - mesh.position.x;
         var lOff = box.min.x - mesh.position.x;
@@ -1565,8 +1765,11 @@ window.addEventListener('load', function() {
         var bestX = null, bestZ = null;
         var bestDX = FACE_SNAP_THRESHOLD, bestDZ = FACE_SNAP_THRESHOLD;
 
+        var isGroup = mesh instanceof THREE.Group;
         pieces.forEach(function(other) {
             if (other === mesh) return;
+            // When dragging a group, don't snap to its own children
+            if (isGroup && other.parent === mesh) return;
             var ob = new THREE.Box3().setFromObject(other);
             var ocx = (ob.min.x + ob.max.x) / 2;
             var ocz = (ob.min.z + ob.max.z) / 2;
@@ -1609,10 +1812,15 @@ window.addEventListener('load', function() {
             }
         });
 
+        // Only report "snapped" when the correction is visible (delta > epsilon),
+        // so the indicator doesn't flash when already sitting on an alignment.
+        var EPS = 0.5;
+        var snappedX = bestX !== null && Math.abs(bestX - xVal) > EPS;
+        var snappedZ = bestZ !== null && Math.abs(bestZ - zVal) > EPS;
         return {
             x: bestX !== null ? bestX : snapValue(xVal),
             z: bestZ !== null ? bestZ : snapValue(zVal),
-            snapped: bestX !== null || bestZ !== null
+            snapped: snappedX || snappedZ
         };
     }
 
@@ -1620,6 +1828,7 @@ window.addEventListener('load', function() {
     // For Dowels: additionally snaps the center (position.y) to piece faces for half-insertion.
     function faceSnapY(mesh, yVal) {
         mesh.position.y = yVal;
+        mesh.updateMatrixWorld(true);
         var box = new THREE.Box3().setFromObject(mesh);
         var tOff = box.max.y - mesh.position.y;
         var bOff = box.min.y - mesh.position.y;
@@ -1628,8 +1837,10 @@ window.addEventListener('load', function() {
         var bestY = null;
         var bestD = FACE_SNAP_THRESHOLD;
 
+        var isGroup = mesh instanceof THREE.Group;
         pieces.forEach(function(other) {
             if (other === mesh) return;
+            if (isGroup && other.parent === mesh) return;
             var ob = new THREE.Box3().setFromObject(other);
             var d;
             // Top/bottom contact
@@ -1651,7 +1862,9 @@ window.addEventListener('load', function() {
             }
         });
 
-        return bestY !== null ? { y: bestY, snapped: true } : { y: snapValue(yVal), snapped: false };
+        var EPS = 0.5;
+        var snappedY = bestY !== null && Math.abs(bestY - yVal) > EPS;
+        return bestY !== null ? { y: bestY, snapped: snappedY } : { y: snapValue(yVal), snapped: false };
     }
 
     function onPosChange() {
@@ -1828,9 +2041,15 @@ window.addEventListener('load', function() {
     // ============================================================
 
     function serializeScene() {
-        var state = [];
+        var _wp = new THREE.Vector3();
+        var _wq = new THREE.Quaternion();
+        var piecesState = [];
         pieces.forEach(function(mesh) {
             var ud = mesh.userData;
+            // Always save world position so grouped pieces serialize correctly
+            mesh.getWorldPosition(_wp);
+            mesh.getWorldQuaternion(_wq);
+            var _we = new THREE.Euler().setFromQuaternion(_wq, 'XYZ');
             var entry = {
                 type: ud.type, id: ud.id, label: ud.label, notches: ud.notches,
                 csgModified: ud.csgModified,
@@ -1839,8 +2058,9 @@ window.addEventListener('load', function() {
                 sourcePrice: ud.sourcePrice || 0,
                 sourcePriceMode: ud.sourcePriceMode || null,
                 sourceLabel: ud.sourceLabel || null,
-                px: mesh.position.x, py: mesh.position.y, pz: mesh.position.z,
-                rx: mesh.rotation.x, ry: mesh.rotation.y, rz: mesh.rotation.z
+                groupId: ud.groupId || null,
+                px: _wp.x, py: _wp.y, pz: _wp.z,
+                rx: _we.x, ry: _we.y, rz: _we.z
             };
             if (ud.type === 'Board' || ud.type === 'Wedge' || ud.type === 'L-Bracket') {
                 entry.w = ud.w; entry.h = ud.h; entry.d = ud.d;
@@ -1850,22 +2070,30 @@ window.addEventListener('load', function() {
                 entry.rTop = ud.rTop; entry.rBottom = ud.rBottom; entry.h = ud.h;
             }
             if (ud.csgModified) {
-                // Store raw geometry data
                 var pos = mesh.geometry.attributes.position.array;
                 var norm = mesh.geometry.attributes.normal.array;
                 entry.geoPositions = Array.prototype.slice.call(pos);
                 entry.geoNormals = Array.prototype.slice.call(norm);
             }
-            state.push(entry);
+            piecesState.push(entry);
         });
-        return JSON.stringify(state);
+        var groupsState = groups.map(function(g) {
+            return { gId: g.userData.gId, px: g.position.x, py: g.position.y, pz: g.position.z,
+                rx: g.rotation.x, ry: g.rotation.y, rz: g.rotation.z };
+        });
+        return JSON.stringify({ pieces: piecesState, groups: groupsState });
     }
 
     function restoreScene(json) {
-        // Clear current
+        // Clear groups
+        groups.forEach(function(g) { scene.remove(g); });
+        groups = [];
+        selectedGroup = null;
+        multiSelected.clear();
+        // Clear pieces
         pieces.forEach(function(m) {
             removeLabel(m);
-            scene.remove(m);
+            if (m.parent) m.parent.remove(m);
             m.geometry.dispose();
             m.material.dispose();
         });
@@ -1873,10 +2101,13 @@ window.addEventListener('load', function() {
         selectedPiece = null;
 
         var state = JSON.parse(json);
-        state.forEach(function(entry) {
+        // Support old format (plain array) and new format ({pieces, groups})
+        var piecesData = Array.isArray(state) ? state : (state.pieces || []);
+        var groupsData = Array.isArray(state) ? [] : (state.groups || []);
+
+        function restoreMesh(entry) {
             var mesh;
             if (entry.csgModified) {
-                // Restore from raw geometry
                 var geo = new THREE.BufferGeometry();
                 geo.setAttribute('position', new THREE.Float32BufferAttribute(entry.geoPositions, 3));
                 geo.setAttribute('normal', new THREE.Float32BufferAttribute(entry.geoNormals, 3));
@@ -1889,11 +2120,11 @@ window.addEventListener('load', function() {
                 else if (entry.type === 'Wedge') mesh = makeWedge(entry.w, entry.h, entry.d);
                 else if (entry.type === 'L-Bracket') mesh = makeLBracket(entry.w, entry.h, entry.d);
                 else if (entry.type === 'Tapered Leg') mesh = makeTaperedLeg(entry.rTop, entry.rBottom, entry.h);
-                // Undo the pieceCounter increment from factory
                 pieceCounter--;
             }
             mesh.position.set(entry.px, entry.py, entry.pz);
             mesh.rotation.set(entry.rx, entry.ry, entry.rz);
+            mesh.userData.type = entry.type;
             mesh.userData.id = entry.id;
             mesh.userData.label = entry.label;
             mesh.userData.notches = entry.notches;
@@ -1904,6 +2135,7 @@ window.addEventListener('load', function() {
             mesh.userData.sourcePrice = entry.sourcePrice || 0;
             mesh.userData.sourcePriceMode = entry.sourcePriceMode || null;
             mesh.userData.sourceLabel = entry.sourceLabel || null;
+            mesh.userData.groupId = entry.groupId || null;
             if (entry.type === 'Board' || entry.type === 'Wedge' || entry.type === 'L-Bracket') {
                 mesh.userData.w = entry.w; mesh.userData.h = entry.h; mesh.userData.d = entry.d;
             } else if (entry.type === 'Dowel') {
@@ -1911,11 +2143,39 @@ window.addEventListener('load', function() {
             } else if (entry.type === 'Tapered Leg') {
                 mesh.userData.rTop = entry.rTop; mesh.userData.rBottom = entry.rBottom; mesh.userData.h = entry.h;
             }
+            return mesh;
+        }
+
+        // First pass: restore all pieces at world positions in scene
+        piecesData.forEach(function(entry) {
+            var mesh = restoreMesh(entry);
             scene.add(mesh);
             pieces.push(mesh);
-            if (labelsVisible) createLabel(mesh);
+            if (labelsVisible && !entry.groupId) createLabel(mesh);
             applyXray(mesh);
         });
+
+        // Second pass: restore groups and attach children
+        groupsData.forEach(function(gEntry) {
+            var group = new THREE.Group();
+            group.userData.gId = gEntry.gId;
+            group.position.set(gEntry.px, gEntry.py, gEntry.pz);
+            group.rotation.set(gEntry.rx, gEntry.ry, gEntry.rz);
+            scene.add(group);
+            groups.push(group);
+            group.updateMatrixWorld(true);
+            pieces.forEach(function(m) {
+                if (m.userData.groupId === gEntry.gId) {
+                    scene.remove(m);
+                    var localPos = group.worldToLocal(m.position.clone());
+                    m.position.copy(localPos);
+                    group.add(m);
+                }
+            });
+            var n = parseInt(gEntry.gId.replace('grp_', ''), 10);
+            if (!isNaN(n) && n > groupCounter) groupCounter = n;
+        });
+
         selectPiece(null);
         updateGrid();
     }
@@ -1947,11 +2207,13 @@ window.addEventListener('load', function() {
     function saveModel() {
         var name = prompt(t('save.projectName'), t('save.defaultName'));
         if (name === null) return;
+        var sceneData = JSON.parse(serializeScene());
         var data = {
-            version: 1,
+            version: 2,
             name: name,
             created: new Date().toISOString(),
-            pieces: JSON.parse(serializeScene())
+            pieces: sceneData.pieces,
+            groups: sceneData.groups || []
         };
         var blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
         var url = URL.createObjectURL(blob);
@@ -1972,20 +2234,24 @@ window.addEventListener('load', function() {
                     mergeImportedTemplates(data);
                     return;
                 }
-                var piecesData;
-                // Support both wrapped format (version 1) and raw array (undo format)
-                if (data.version && data.pieces) {
-                    piecesData = data.pieces;
+                var scenePayload;
+                if (data.version >= 2 && data.pieces) {
+                    // New format with groups
+                    scenePayload = { pieces: data.pieces, groups: data.groups || [] };
+                } else if (data.version === 1 && data.pieces) {
+                    // Old format without groups
+                    scenePayload = { pieces: data.pieces, groups: [] };
                 } else if (Array.isArray(data)) {
-                    piecesData = data;
+                    // Raw array (legacy undo format)
+                    scenePayload = data;
                 } else {
                     alert(t('load.invalid'));
                     return;
                 }
-                if (pieces.length > 0) {
+                if (pieces.length > 0 || groups.length > 0) {
                     if (!confirm(t('load.replace'))) return;
                 }
-                restoreScene(JSON.stringify(piecesData));
+                restoreScene(JSON.stringify(scenePayload));
                 updateObjectList();
             } catch (err) {
                 alert(t('load.failed', { msg: err.message }));
@@ -2233,11 +2499,16 @@ window.addEventListener('load', function() {
             else if (ud.type === 'L-Bracket') mesh = makeLBracket(ud.w, ud.h, ud.d);
             else if (ud.type === 'Tapered Leg') mesh = makeTaperedLeg(ud.rTop, ud.rBottom, ud.h);
         }
-        // Copy transform with a small offset so it's visible
-        mesh.position.copy(selectedPiece.position);
+        // Copy transform with a small offset so it's visible.
+        // Use world transforms so duplicates of grouped pieces land at correct scene position.
+        var srcWorldPos = new THREE.Vector3();
+        var srcWorldQuat = new THREE.Quaternion();
+        selectedPiece.getWorldPosition(srcWorldPos);
+        selectedPiece.getWorldQuaternion(srcWorldQuat);
+        mesh.position.copy(srcWorldPos);
         mesh.position.x += 30;
         mesh.position.z += 30;
-        mesh.rotation.copy(selectedPiece.rotation);
+        mesh.quaternion.copy(srcWorldQuat);
         // Copy userData
         mesh.userData.type = ud.type;
         mesh.userData.id = ++pieceCounter;
@@ -2452,8 +2723,12 @@ window.addEventListener('load', function() {
 
         var src = selectedPiece;
         var ud = src.userData;
-        var srcPos = src.position.clone();
-        var srcQuat = src.quaternion.clone();
+        // Use world transforms so splits work correctly when src is inside a Group
+        var srcParent = src.parent || scene;
+        var srcPos = new THREE.Vector3();
+        var srcQuat = new THREE.Quaternion();
+        src.getWorldPosition(srcPos);
+        src.getWorldQuaternion(srcQuat);
         var baseLabel = ud.label || ud.type;
         var price = ud.price || 0;
         var priceMode = ud.priceMode || 'fixed';
@@ -2472,11 +2747,11 @@ window.addEventListener('load', function() {
         else localDir = new THREE.Vector3(0, 0, 1);
         var worldDir = localDir.clone().applyQuaternion(srcQuat);
 
-        // Remove original
+        // Remove original from its actual parent (scene or enclosing group)
         var srcIdx = pieces.indexOf(src);
         if (srcIdx !== -1) pieces.splice(srcIdx, 1);
         removeLabel(src);
-        scene.remove(src);
+        srcParent.remove(src);
         src.geometry.dispose();
         src.material.dispose();
         selectedPiece = null;
@@ -2495,6 +2770,8 @@ window.addEventListener('load', function() {
             } else {
                 mesh = makeDowel(ud.r, partLen);
             }
+            // Set world transform first, then attach to srcParent preserving it
+            scene.add(mesh);
             mesh.quaternion.copy(srcQuat);
             mesh.position.copy(srcPos).add(worldDir.clone().multiplyScalar(offsetCenter));
             mesh.userData.label = label;
@@ -2506,9 +2783,12 @@ window.addEventListener('load', function() {
                 mesh.userData.sourcePriceMode = sourcePriceMode;
                 mesh.userData.sourceLabel = sourceLabel;
             }
-            scene.add(mesh);
+            if (srcParent !== scene && srcParent instanceof THREE.Group) {
+                srcParent.attach(mesh);
+                mesh.userData.groupId = srcParent.userData.gId;
+            }
             pieces.push(mesh);
-            if (labelsVisible) createLabel(mesh);
+            if (labelsVisible && !mesh.userData.groupId) createLabel(mesh);
             applyXray(mesh);
             created.push(mesh);
         }
@@ -2532,12 +2812,30 @@ window.addEventListener('load', function() {
     }
 
     function deleteSelected() {
+        if (selectedGroup) {
+            pushUndo();
+            var grp = selectedGroup;
+            grp.children.slice().forEach(function(m) {
+                var idx = pieces.indexOf(m);
+                if (idx !== -1) pieces.splice(idx, 1);
+                removeLabel(m);
+                m.geometry.dispose();
+                m.material.dispose();
+            });
+            deselectGroup();
+            scene.remove(grp);
+            var gi = groups.indexOf(grp);
+            if (gi !== -1) groups.splice(gi, 1);
+            selectPiece(null);
+            updateGrid();
+            return;
+        }
         if (!selectedPiece) return;
         pushUndo();
         var idx = pieces.indexOf(selectedPiece);
         if (idx !== -1) pieces.splice(idx, 1);
         removeLabel(selectedPiece);
-        scene.remove(selectedPiece);
+        if (selectedPiece.parent) selectedPiece.parent.remove(selectedPiece);
         selectedPiece.geometry.dispose();
         selectedPiece.material.dispose();
         selectedPiece = null;
@@ -2546,17 +2844,22 @@ window.addEventListener('load', function() {
     }
 
     function clearAll() {
-        if (pieces.length === 0) return;
+        if (pieces.length === 0 && groups.length === 0) return;
         if (!confirm(t('clearAll.confirm'))) return;
         pushUndo();
         pieces.forEach(function(m) {
             removeLabel(m);
-            scene.remove(m);
+            if (m.parent) m.parent.remove(m);
             m.geometry.dispose();
             m.material.dispose();
         });
+        groups.forEach(function(g) { scene.remove(g); });
+        groups = [];
+        selectedGroup = null;
+        multiSelected.clear();
         pieces = [];
         selectedPiece = null;
+        document.getElementById('group-panel').style.display = 'none';
         selectPiece(null);
         updateGrid();
     }
@@ -2625,6 +2928,8 @@ window.addEventListener('load', function() {
 
     // Drag-to-move state
     var dragMode = false;
+    var wasSnappedXZ = false;
+    var wasSnappedY = false;
     var dragPiece = null;
     var dragPlane = new THREE.Plane();
     var dragOffset = new THREE.Vector3();
@@ -2646,6 +2951,10 @@ window.addEventListener('load', function() {
         // Don't start object drag in cut mode
         if (cutMode) return;
 
+        // Ctrl+click is reserved for multi-select (handled in click handler).
+        // Skip drag/select setup so the click can toggle selection cleanly.
+        if (e.ctrlKey || e.metaKey) return;
+
         // Raycast to see if we hit a piece
         getMouseNDC(e);
         raycaster.setFromCamera(mouse, camera);
@@ -2653,16 +2962,25 @@ window.addEventListener('load', function() {
         var intersects = raycaster.intersectObjects(meshes, false);
 
         if (intersects.length > 0) {
-            // Prefer the already-selected piece when multiple overlap
-            dragPiece = intersects[0].object;
+            // Prefer already-selected piece or group member
+            var hitMesh = intersects[0].object;
             for (var i = 0; i < intersects.length; i++) {
-                if (intersects[i].object === selectedPiece) {
-                    dragPiece = selectedPiece;
-                    break;
-                }
+                var obj = intersects[i].object;
+                if (obj === selectedPiece) { hitMesh = obj; break; }
+                if (selectedGroup && obj.userData.groupId === selectedGroup.userData.gId) { hitMesh = obj; break; }
+            }
+            // Resolve to group if the hit mesh belongs to one
+            if (hitMesh.userData.groupId) {
+                dragPiece = findGroupById(hitMesh.userData.groupId) || hitMesh;
+            } else {
+                dragPiece = hitMesh;
             }
             dragMode = true;
-            selectPiece(dragPiece);
+            if (dragPiece instanceof THREE.Group) {
+                selectGroup(dragPiece);
+            } else {
+                selectPiece(dragPiece);
+            }
 
             // Build drag plane
             if (e.shiftKey) {
@@ -2707,13 +3025,17 @@ window.addEventListener('load', function() {
             if (raycaster.ray.intersectPlane(dragPlane, dragIntersect)) {
                 var newPos = dragIntersect.add(dragOffset);
 
+                var isGroupDrag = dragPiece instanceof THREE.Group;
                 if (e.shiftKey) {
                     // Only update Y
                     var yVal = newPos.y;
                     if (snapEnabled) {
                         var ys = faceSnapY(dragPiece, yVal);
-                        if (ys.snapped) flashSnap();
+                        if (ys.snapped && !wasSnappedY) flashSnap();
+                        wasSnappedY = ys.snapped;
                         yVal = ys.y;
+                    } else {
+                        wasSnappedY = false;
                     }
                     dragPiece.position.y = yVal;
                 } else {
@@ -2722,9 +3044,12 @@ window.addEventListener('load', function() {
                     var zVal = newPos.z;
                     if (snapEnabled) {
                         var fs = faceSnapXZ(dragPiece, xVal, zVal);
-                        if (fs.snapped) flashSnap();
+                        if (fs.snapped && !wasSnappedXZ) flashSnap();
+                        wasSnappedXZ = fs.snapped;
                         xVal = fs.x;
                         zVal = fs.z;
+                    } else {
+                        wasSnappedXZ = false;
                     }
                     dragPiece.position.x = xVal;
                     dragPiece.position.z = zVal;
@@ -2735,9 +3060,13 @@ window.addEventListener('load', function() {
                     inputPX.value = Math.round(dragPiece.position.x);
                     inputPY.value = Math.round(dragPiece.position.y);
                     inputPZ.value = Math.round(dragPiece.position.z);
+                } else if (isGroupDrag && dragPiece === selectedGroup) {
+                    document.getElementById('grp-pos-x').value = Math.round(dragPiece.position.x);
+                    document.getElementById('grp-pos-y').value = Math.round(dragPiece.position.y);
+                    document.getElementById('grp-pos-z').value = Math.round(dragPiece.position.z);
                 }
 
-                if (labelsVisible) updateLabelPosition(dragPiece);
+                if (labelsVisible && !isGroupDrag) updateLabelPosition(dragPiece);
             }
             return;
         }
@@ -2760,6 +3089,8 @@ window.addEventListener('load', function() {
             controls._enabled = true;
             dragMode = false;
             dragPiece = null;
+            wasSnappedXZ = false;
+            wasSnappedY = false;
             renderer.domElement.style.cursor = '';
             if (dragStarted) {
                 // Was a real drag — don't fire click-to-select
@@ -2795,9 +3126,24 @@ window.addEventListener('load', function() {
             return;
         }
 
+        if (e.ctrlKey) {
+            // Ctrl+click: toggle multi-select for grouping
+            if (intersects.length > 0) toggleMultiSelect(intersects[0].object);
+            return;
+        }
+
         if (intersects.length > 0) {
-            selectPiece(intersects[0].object);
+            var clickedMesh = intersects[0].object;
+            if (clickedMesh.userData.groupId) {
+                var grp = findGroupById(clickedMesh.userData.groupId);
+                if (grp) { selectGroup(grp); return; }
+            }
+            selectPiece(clickedMesh);
         } else {
+            deselectGroup();
+            multiSelected.forEach(function(m) { m.material.color.setHex(WOOD_COLOR); });
+            multiSelected.clear();
+            updateGroupButton();
             selectPiece(null);
         }
     });
@@ -3000,7 +3346,24 @@ window.addEventListener('load', function() {
     document.getElementById('btn-undo').addEventListener('click', undo);
     document.getElementById('btn-redo').addEventListener('click', redo);
     document.getElementById('btn-duplicate').addEventListener('click', duplicateSelected);
+    document.getElementById('btn-group').addEventListener('click', createGroup);
     document.getElementById('btn-delete').addEventListener('click', deleteSelected);
+    document.getElementById('btn-ungroup').addEventListener('click', ungroup);
+
+    // Group position inputs
+    function onGroupPosChange() {
+        if (!selectedGroup) return;
+        pushUndo();
+        selectedGroup.position.x = parseFloat(document.getElementById('grp-pos-x').value) || 0;
+        selectedGroup.position.y = parseFloat(document.getElementById('grp-pos-y').value) || 0;
+        selectedGroup.position.z = parseFloat(document.getElementById('grp-pos-z').value) || 0;
+        updateGrid();
+    }
+    ['grp-pos-x', 'grp-pos-y', 'grp-pos-z'].forEach(function(id) {
+        var inp = document.getElementById(id);
+        inp.addEventListener('change', onGroupPosChange);
+        bindEnter(inp, onGroupPosChange);
+    });
     document.getElementById('btn-clear').addEventListener('click', clearAll);
     document.getElementById('btn-export').addEventListener('click', exportCSV);
 
@@ -3074,6 +3437,9 @@ window.addEventListener('load', function() {
         if (labelsBtn) labelsBtn.textContent = labelsVisible ? t('toolbar.labels.on') : t('toolbar.labels.off');
         var xrayBtn = document.getElementById('btn-xray');
         if (xrayBtn) xrayBtn.textContent = xrayMode ? t('toolbar.xray.on') : t('toolbar.xray.off');
+        var groupBtn = document.getElementById('btn-group');
+        if (groupBtn) groupBtn.textContent = t('toolbar.group');
+        updateGroupButton();
         updateObjectList();
         updateSizeSummary();
         updateCostSummary();


### PR DESCRIPTION
## Summary
- Multi-select pieces (Ctrl+click) and group/ungroup them via toolbar buttons
- Groups move and snap as a single unit; children are excluded from self-snap
- Split/duplicate inside groups use world transforms so positions stay correct and split parts stay in the group
- Serialization persists groups; `restoreMesh` now sets `userData.type` so CSG pieces survive load/save
- Snap indicator only fires on no-snap → snap transition (no more flashing while moving along an alignment)
- Docs: also documents X-Ray mode and template import/export that were previously missing

## Test plan
- [x] Ctrl+click multi-select and Group/Ungroup buttons
- [x] Drag group onto ungrouped piece snaps correctly
- [x] Drag ungrouped piece onto group snaps correctly
- [x] Split a piece inside a group keeps parts in the group
- [x] Duplicate a piece inside a group lands at correct world position
- [x] Save/Load round-trip with CSG-modified piece preserves type and dimensions
- [x] Undo/Redo with group operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)