### PR TITLE
chore: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,7 +10,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` from `v4` (Node.js 20) to `v5` (Node.js 24).
- Resolves the deprecation warning in the Auto Release workflow ahead of GitHub's June 2026 cutover.

## Test plan
- [ ] Trigger the Auto Release workflow manually and confirm it completes without the Node 20 deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)