### PR TITLE
ci: restore Pages deploy step on release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -75,3 +75,20 @@ jobs:
           gh release create "${{ steps.version.outputs.tag }}" \
             --title "${{ steps.version.outputs.tag }}" \
             --notes-file release_notes.txt
+
+      - name: Deploy to GitHub Pages
+        if: steps.bump.outputs.bump != 'none'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          cp index.html /tmp/deploy_index.html
+          if git ls-remote --exit-code --heads origin gh-pages > /dev/null; then
+            git checkout gh-pages
+          else
+            git checkout --orphan gh-pages
+            git rm -rf .
+          fi
+          cp /tmp/deploy_index.html index.html
+          git add index.html
+          git diff --staged --quiet || git commit -m "deploy: ${{ steps.version.outputs.tag }}"
+          git push origin gh-pages


### PR DESCRIPTION
## Summary
- Restores the `Deploy to GitHub Pages` step in `.github/workflows/auto-release.yml`. The step was lost when feature/xray-mode was merged with an older base — gh-pages has been stale (still on the source-groups commit) since April 23, 2026, which is why the live demo doesn't show X-Ray, Grouping, or Ruler.
- After this PR, the next manual workflow_dispatch run that creates a release will also push the current `index.html` to the `gh-pages` branch.

## Test plan
- [ ] Trigger the Auto Release workflow manually after merge.
- [ ] Confirm a new commit appears on `gh-pages`.
- [ ] Confirm `https://urfin78.github.io/3d-wooden-modeler/` shows the Ruler / X-Ray / Grouping toolbar buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)