### PR TITLE
docs: add JSON schema reference files for .woodmodel.json and .woodtemplates.json

### DIFF
--- a/woodmodel.schema.json
+++ b/woodmodel.schema.json
@@ -1,0 +1,227 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "woodmodel.schema.json",
+  "title": "3D Wooden Modeler — Model File (.woodmodel.json)",
+  "description": "Saved scene produced by saveModel(). Current version: 3. Backwards-compatible loaders handle v1 (no groups), v2 (groups, no rulers) and v3 (groups + rulers).",
+  "type": "object",
+  "required": ["version", "name", "created", "pieces"],
+  "properties": {
+
+    "version": {
+      "description": "Format version. 1 = pieces only; 2 = + groups; 3 = + rulers.",
+      "type": "integer",
+      "enum": [1, 2, 3]
+    },
+
+    "name": {
+      "description": "User-supplied project name (prompted on Save).",
+      "type": "string"
+    },
+
+    "created": {
+      "description": "ISO 8601 timestamp of when the file was saved.",
+      "type": "string",
+      "format": "date-time"
+    },
+
+    "pieces": {
+      "description": "Ordered list of all scene pieces. Groups are reconstructed from groupId references in a second pass.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type", "id", "px", "py", "pz", "rx", "ry", "rz"],
+        "properties": {
+
+          "type": {
+            "description": "Fixed English identifier for the piece shape. Never translated; used as a discriminator for dimension fields.",
+            "type": "string",
+            "enum": ["Board", "Dowel", "Wedge", "L-Bracket", "Tapered Leg"]
+          },
+
+          "id": {
+            "description": "Stable numeric auto-increment ID assigned by addPiece() (pieceCounter). Unique within a saved file but not across files.",
+            "type": "integer"
+          },
+
+          "label": {
+            "description": "User-editable display name shown as a 3D sprite and in the object list. Null or empty string when not set.",
+            "type": ["string", "null"]
+          },
+
+          "notches": {
+            "description": "Count of CSG Cut Joint operations applied to this piece. Purely informational (used in CSV export).",
+            "type": "integer",
+            "minimum": 0
+          },
+
+          "csgModified": {
+            "description": "True when the piece geometry was altered by at least one Cut Joint. When true, geoPositions and geoNormals must be present and the shape-specific dimension fields are no longer used to rebuild geometry.",
+            "type": "boolean"
+          },
+
+          "price": {
+            "description": "Per-piece price. Interpretation depends on priceMode. 0 for split-part members that belong to a source group (cost counted once via sourcePrice).",
+            "type": "number",
+            "minimum": 0
+          },
+
+          "priceMode": {
+            "description": "'fixed' = price is the total cost for this piece. 'per_mm' = price × relevant dimension (length along the split axis for Boards/Dowels) gives the cost.",
+            "type": "string",
+            "enum": ["fixed", "per_mm"]
+          },
+
+          "sourceId": {
+            "description": "Shared UUID assigned to all parts produced from the same Split operation ('source group'). Null when not a split part.",
+            "type": ["string", "null"]
+          },
+
+          "sourcePrice": {
+            "description": "Original price of the unsplit board/dowel. Used to display the group cost once in the cost summary and CSV. 0 when not a split part.",
+            "type": "number",
+            "minimum": 0
+          },
+
+          "sourcePriceMode": {
+            "description": "priceMode of the original unsplit piece. Null when not a split part.",
+            "type": ["string", "null"],
+            "enum": ["fixed", "per_mm", null]
+          },
+
+          "sourceLabel": {
+            "description": "Label of the original unsplit piece. Null when not a split part.",
+            "type": ["string", "null"]
+          },
+
+          "groupId": {
+            "description": "gId of the THREE.Group this piece belongs to (e.g. 'grp_1'). Null for ungrouped pieces.",
+            "type": ["string", "null"]
+          },
+
+          "px": { "description": "World-space X position in mm.", "type": "number" },
+          "py": { "description": "World-space Y position in mm.", "type": "number" },
+          "pz": { "description": "World-space Z position in mm.", "type": "number" },
+
+          "rx": { "description": "X rotation in radians (Euler XYZ order).", "type": "number" },
+          "ry": { "description": "Y rotation in radians (Euler XYZ order).", "type": "number" },
+          "rz": { "description": "Z rotation in radians (Euler XYZ order).", "type": "number" },
+
+          "w": {
+            "description": "Width in mm. Required for Board, Wedge, L-Bracket.",
+            "type": "number", "exclusiveMinimum": 0
+          },
+          "h": {
+            "description": "Height in mm. Required for Board, Wedge, L-Bracket, Dowel, Tapered Leg.",
+            "type": "number", "exclusiveMinimum": 0
+          },
+          "d": {
+            "description": "Depth in mm. Required for Board, Wedge, L-Bracket.",
+            "type": "number", "exclusiveMinimum": 0
+          },
+          "r": {
+            "description": "Radius in mm. Required for Dowel.",
+            "type": "number", "exclusiveMinimum": 0
+          },
+          "rTop": {
+            "description": "Top radius in mm. Required for Tapered Leg.",
+            "type": "number", "exclusiveMinimum": 0
+          },
+          "rBottom": {
+            "description": "Bottom radius in mm. Required for Tapered Leg.",
+            "type": "number", "exclusiveMinimum": 0
+          },
+
+          "geoPositions": {
+            "description": "Flat array of vertex XYZ coordinates for CSG-modified geometry (BufferGeometry position attribute). Present only when csgModified is true.",
+            "type": "array",
+            "items": { "type": "number" }
+          },
+          "geoNormals": {
+            "description": "Flat array of vertex normal XYZ values for CSG-modified geometry (BufferGeometry normal attribute). Same length as geoPositions. Present only when csgModified is true.",
+            "type": "array",
+            "items": { "type": "number" }
+          }
+        }
+      }
+    },
+
+    "groups": {
+      "description": "THREE.Group containers. Empty array in v1 files. Pieces reference their group via groupId.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["gId", "px", "py", "pz", "rx", "ry", "rz"],
+        "properties": {
+          "gId": {
+            "description": "Unique group identifier, format 'grp_<n>' where n is a monotonic integer (groupCounter).",
+            "type": "string",
+            "pattern": "^grp_[0-9]+$"
+          },
+          "px": { "description": "Group X position in mm.", "type": "number" },
+          "py": { "description": "Group Y position in mm.", "type": "number" },
+          "pz": { "description": "Group Z position in mm.", "type": "number" },
+          "rx": { "description": "Group X rotation in radians (Euler XYZ).", "type": "number" },
+          "ry": { "description": "Group Y rotation in radians (Euler XYZ).", "type": "number" },
+          "rz": { "description": "Group Z rotation in radians (Euler XYZ).", "type": "number" }
+        }
+      }
+    },
+
+    "rulers": {
+      "description": "Persistent measurement lines. Empty array in v1/v2 files.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["p1", "p2"],
+        "properties": {
+          "p1": {
+            "description": "Start point [x, y, z] in world-space mm.",
+            "type": "array",
+            "items": { "type": "number" },
+            "minItems": 3,
+            "maxItems": 3
+          },
+          "p2": {
+            "description": "End point [x, y, z] in world-space mm.",
+            "type": "array",
+            "items": { "type": "number" },
+            "minItems": 3,
+            "maxItems": 3
+          }
+        }
+      }
+    }
+
+  },
+
+  "examples": [
+    {
+      "version": 3,
+      "name": "Simple shelf",
+      "created": "2026-04-29T12:00:00.000Z",
+      "pieces": [
+        {
+          "type": "Board",
+          "id": 1,
+          "label": "Shelf board",
+          "notches": 0,
+          "csgModified": false,
+          "price": 12.50,
+          "priceMode": "fixed",
+          "sourceId": null,
+          "sourcePrice": 0,
+          "sourcePriceMode": null,
+          "sourceLabel": null,
+          "groupId": null,
+          "px": 0, "py": 10, "pz": 0,
+          "rx": 0, "ry": 0, "rz": 0,
+          "w": 600, "h": 20, "d": 200
+        }
+      ],
+      "groups": [],
+      "rulers": [
+        { "p1": [0, 20, 0], "p2": [600, 20, 0] }
+      ]
+    }
+  ]
+}

--- a/woodtemplates.schema.json
+++ b/woodtemplates.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "woodtemplates.schema.json",
+  "title": "3D Wooden Modeler — Template Library File (.woodtemplates.json)",
+  "description": "Exported custom template library produced by exportTemplates(). An array of template objects; the same format is stored in localStorage under 'woodmodeler_templates'. Built-in templates follow the same shape but also carry a nameKey for i18n translation.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["name", "type"],
+    "properties": {
+
+      "name": {
+        "description": "Display name of the template. Shown in the + Add mega-dropdown and used as the deduplication key on import (existing templates with the same name are skipped).",
+        "type": "string",
+        "minLength": 1
+      },
+
+      "nameKey": {
+        "description": "Optional i18n translation key (e.g. 'template.builtIn.board2x4'). Present on built-in templates; absent on user-created ones. When present, the translated string overrides 'name' in the UI.",
+        "type": "string"
+      },
+
+      "type": {
+        "description": "Piece shape. Must match one of the fixed English identifiers used in the app.",
+        "type": "string",
+        "enum": ["Board", "Dowel", "Wedge", "L-Bracket", "Tapered Leg"]
+      },
+
+      "price": {
+        "description": "Default price applied when adding a piece from this template (fixed mode). Optional; defaults to 0.",
+        "type": "number",
+        "minimum": 0
+      },
+
+      "w": {
+        "description": "Width in mm. Required for Board, Wedge, L-Bracket.",
+        "type": "number", "exclusiveMinimum": 0
+      },
+      "h": {
+        "description": "Height in mm. Required for Board, Wedge, L-Bracket, Dowel, Tapered Leg.",
+        "type": "number", "exclusiveMinimum": 0
+      },
+      "d": {
+        "description": "Depth in mm. Required for Board, Wedge, L-Bracket.",
+        "type": "number", "exclusiveMinimum": 0
+      },
+      "r": {
+        "description": "Radius in mm. Required for Dowel.",
+        "type": "number", "exclusiveMinimum": 0
+      },
+      "rTop": {
+        "description": "Top radius in mm. Required for Tapered Leg.",
+        "type": "number", "exclusiveMinimum": 0
+      },
+      "rBottom": {
+        "description": "Bottom radius in mm. Required for Tapered Leg.",
+        "type": "number", "exclusiveMinimum": 0
+      }
+    },
+
+    "allOf": [
+      {
+        "if": { "properties": { "type": { "const": "Board" } } },
+        "then": { "required": ["w", "h", "d"] }
+      },
+      {
+        "if": { "properties": { "type": { "const": "Wedge" } } },
+        "then": { "required": ["w", "h", "d"] }
+      },
+      {
+        "if": { "properties": { "type": { "const": "L-Bracket" } } },
+        "then": { "required": ["w", "h", "d"] }
+      },
+      {
+        "if": { "properties": { "type": { "const": "Dowel" } } },
+        "then": { "required": ["r", "h"] }
+      },
+      {
+        "if": { "properties": { "type": { "const": "Tapered Leg" } } },
+        "then": { "required": ["rTop", "rBottom", "h"] }
+      }
+    ]
+  },
+
+  "examples": [
+    [
+      {
+        "name": "Shelf board 600×20×200",
+        "type": "Board",
+        "price": 12.50,
+        "w": 600, "h": 20, "d": 200
+      },
+      {
+        "name": "8mm dowel 60mm",
+        "type": "Dowel",
+        "price": 0.50,
+        "r": 4, "h": 60
+      },
+      {
+        "name": "Tapered table leg",
+        "type": "Tapered Leg",
+        "price": 8.00,
+        "rTop": 15, "rBottom": 25, "h": 720
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
## Summary

Adds two annotated JSON Schema (draft-07) files to the repo root that were missing from PR #17 (committed after the merge).

- `woodmodel.schema.json` — documents the `.woodmodel.json` save format (v1–v3): all piece fields with types and descriptions, discriminated dimension fields per piece type, CSG geometry blobs, split source groups, groups, rulers, backwards-compat notes, and a minimal example.
- `woodtemplates.schema.json` — documents the `.woodtemplates.json` template library format: template array with conditional `required` rules per piece type and an example.

`CLAUDE.md` already contains the instruction to keep both files in sync when the format changes (merged in #17).

## Test plan
- [ ] Validate `examples/stool.woodmodel.json` against `woodmodel.schema.json` with any JSON Schema validator — should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)