### PR TITLE
Camera pivot: focus on selection or double-click (#25)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Everything runs inside a `window.addEventListener('load', ...)` closure in `inde
 
 1. **CSG BSP-Tree** — Constructive Solid Geometry implementation (Evan Wallace algorithm) for boolean subtraction between meshes. Key functions: `csgFromMesh`, `csgSubtract`.
 
-2. **Three.js Scene Setup** — Renderer, camera, inline minimal OrbitControls, lighting, ground plane, auto-resizing grid (`updateGrid()`).
+2. **Three.js Scene Setup** — Renderer, camera, inline minimal OrbitControls, lighting, ground plane, auto-resizing grid (`updateGrid()`). The orbit pivot (`controls.target`) can be repositioned at runtime: double-click on a piece sets it to the raycast hit point, double-click on empty space recenters on the bounding box of all visible pieces (`focusCameraOnScene()`), and the `F` key calls `focusCameraOn()` for the current selection (single piece, group, or multi-select bbox).
 
 3. **Application State** — Global mutable state: `pieces[]` array, selection state, mode flags (snap, cut, overlap), undo/redo stacks.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A browser-based 3D woodworking modeller for planning and visualizing wooden cons
 ## Features
 
 - **5 shape types**: Board, Dowel, Wedge, L-Bracket, and Tapered Leg
-- **Interactive 3D viewport** with orbit controls (pan, rotate, zoom)
+- **Interactive 3D viewport** with orbit controls (pan, rotate, zoom); double-click a piece to set the orbit pivot, double-click empty space to recenter on the whole model, or press `F` to focus the current selection
 - **Real-time editing** of dimensions, position, and rotation via the side panel
 - **Drag-to-move** pieces directly in the viewport (Shift+drag for vertical movement)
 - **Duplicate** selected piece via the floating action bar or Ctrl+D

--- a/index.html
+++ b/index.html
@@ -4309,6 +4309,36 @@ window.addEventListener('load', function() {
         }
     });
 
+    // Camera pivot focus
+    function focusCameraOn(target) {
+        if (!target) return;
+        var box = new THREE.Box3().setFromObject(target);
+        if (box.isEmpty()) return;
+        var center = box.getCenter(new THREE.Vector3());
+        controls.target.copy(center);
+        controls.update();
+    }
+    function focusCameraOnScene() {
+        if (!pieces.length) return;
+        var box = new THREE.Box3();
+        pieces.forEach(function(m) { if (m.visible) box.expandByObject(m); });
+        if (box.isEmpty()) return;
+        controls.target.copy(box.getCenter(new THREE.Vector3()));
+        controls.update();
+    }
+    renderer.domElement.addEventListener('dblclick', function(e) {
+        if (cutMode || rulerMode) return;
+        getMouseNDC(e);
+        raycaster.setFromCamera(mouse, camera);
+        var hits = raycaster.intersectObjects(pieces.filter(function(m) { return m.visible; }), false);
+        if (hits.length > 0) {
+            controls.target.copy(hits[0].point);
+            controls.update();
+        } else {
+            focusCameraOnScene();
+        }
+    });
+
     // Keyboard shortcuts
     document.addEventListener('keydown', function(e) {
         if (e.ctrlKey && e.key === 'z' && !e.shiftKey) {
@@ -4320,6 +4350,18 @@ window.addEventListener('load', function() {
         } else if (e.ctrlKey && e.key === 'd') {
             e.preventDefault();
             duplicateSelected();
+        } else if ((e.key === 'f' || e.key === 'F') && !e.ctrlKey && !e.metaKey && !e.altKey
+                   && document.activeElement.tagName !== 'INPUT' && document.activeElement.tagName !== 'TEXTAREA') {
+            e.preventDefault();
+            if (selectedGroup) focusCameraOn(selectedGroup);
+            else if (selectedPiece) focusCameraOn(selectedPiece);
+            else if (multiSelected && multiSelected.size > 0) {
+                var box = new THREE.Box3();
+                multiSelected.forEach(function(m) { box.expandByObject(m); });
+                if (!box.isEmpty()) { controls.target.copy(box.getCenter(new THREE.Vector3())); controls.update(); }
+            } else {
+                focusCameraOnScene();
+            }
         } else if (e.key === 'Delete' && document.activeElement.tagName !== 'INPUT' && document.activeElement.tagName !== 'TEXTAREA') {
             deleteSelected();
         } else if (e.key === 'Escape') {


### PR DESCRIPTION
Closes #25.

## Summary
- Double-click a piece sets `controls.target` to the raycast hit point — orbit and zoom now revolve around that point.
- Double-click on empty space recenters the pivot on the bounding box of all visible pieces.
- `F` key focuses the current selection (single piece, group, or multi-select bbox); falls back to the scene bbox if nothing is selected.
- Camera position is left untouched, so the user only sees the pivot move, no jarring view jump.

Implementation lives next to the existing keyboard-shortcut handler; uses `THREE.Box3().setFromObject(...)` for selection / scene bounds and reuses `getMouseNDC` + the existing raycaster for the double-click hit.

## Test plan
- [x] Add a Tapered Leg or any piece far from origin, double-click it, then orbit/zoom — pivot follows the hit point.
- [x] Double-click empty space — pivot recenters on the model.
- [x] Select a group, press `F` — pivot moves to the group center.
- [x] In Cut Joint or Ruler mode, double-click does **not** override mode-specific behavior.
- [x] `F` is ignored while typing in an input field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)