### PR TITLE
Frustum Board primitive (#19)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Everything runs inside a `window.addEventListener('load', ...)` closure in `inde
 
 3. **Application State** — Global mutable state: `pieces[]` array, selection state, mode flags (snap, cut, overlap), undo/redo stacks.
 
-4. **Shape Factory** — `makeBoard`, `makeDowel`, `makeWedge`, `makeLBracket`, `makeTaperedLeg`. Each returns a Three.js Mesh with a `userData` object storing type and dimensions. `addPiece()` registers meshes into the scene and `pieces[]`.
+4. **Shape Factory** — `makeBoard`, `makeDowel`, `makeWedge`, `makeLBracket`, `makeTaperedLeg`, `makeFrustumBoard`. Each returns a Three.js Mesh with a `userData` object storing type and dimensions. `addPiece()` registers meshes into the scene and `pieces[]`. The Frustum Board (`type: 'Frustum Board'`) is a hand-built BufferGeometry built by `frustumBoardGeometry(wTop, wBottom, h, d)` — 8 vertices, 12 triangles; top and bottom faces are both centered on the y axis. `wTop`/`wBottom` may be 0 (collapses to a wedge).
 
 5. **Label System** — 3D sprite labels positioned above pieces using canvas-rendered textures.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A browser-based 3D woodworking modeller for planning and visualizing wooden cons
 
 ## Features
 
-- **5 shape types**: Board, Dowel, Wedge, L-Bracket, and Tapered Leg
+- **6 shape types**: Board, Frustum Board (trapezoidal — different widths at top and bottom), Dowel, Wedge, L-Bracket, and Tapered Leg
 - **Interactive 3D viewport** with orbit controls (pan, rotate, zoom); double-click a piece to set the orbit pivot, double-click empty space to recenter on the whole model, or press `F` to focus the current selection
 - **Real-time editing** of dimensions, position, and rotation via the side panel
 - **Drag-to-move** pieces directly in the viewport (Shift+drag for vertical movement)

--- a/index.html
+++ b/index.html
@@ -794,7 +794,7 @@ window.addEventListener('load', function() {
             'type.Frustum Board': 'Frustum Board',
             'panel.dim.wTop': 'W Top',
             'panel.dim.wBot': 'W Bot',
-            'tpl.frustumBoard': 'Frustum Board 60/100',
+            'tpl.frustumBoard': 'Trapezoid Side 200/300×600',
             'lang.label': 'Language'
         },
         de: {
@@ -952,7 +952,7 @@ window.addEventListener('load', function() {
             'type.Frustum Board': 'Trapez-Brett',
             'panel.dim.wTop': 'B oben',
             'panel.dim.wBot': 'B unten',
-            'tpl.frustumBoard': 'Trapez-Brett 60/100',
+            'tpl.frustumBoard': 'Trapez-Seite 200/300×600',
             'lang.label': 'Sprache'
         }
     };
@@ -2758,7 +2758,7 @@ window.addEventListener('load', function() {
         { nameKey: 'tpl.cornerBrace',type: 'L-Bracket',   w: 50, h: 50, d: 20,   price: 2.00 },
         { nameKey: 'tpl.tableLeg',   type: 'Tapered Leg', rTop: 20, rBottom: 30, h: 720, price: 12.00 },
         { nameKey: 'tpl.doorWedge',  type: 'Wedge',       w: 80, h: 30, d: 40,   price: 1.00 },
-        { nameKey: 'tpl.frustumBoard', type: 'Frustum Board', wTop: 60, wBottom: 100, h: 80, d: 40, price: 3.00 }
+        { nameKey: 'tpl.frustumBoard', type: 'Frustum Board', wTop: 200, wBottom: 300, h: 600, d: 18, price: 9.00 }
     ];
 
     function loadCustomTemplates() {

--- a/index.html
+++ b/index.html
@@ -499,6 +499,16 @@
                 <div><label data-i18n="panel.dim.height">Height</label><input type="number" id="dim-th" step="1" min="1"></div>
             </div>
         </div>
+        <div id="dim-frustum" style="display:none">
+            <div class="input-row">
+                <div><label data-i18n="panel.dim.wTop">W Top</label><input type="number" id="dim-wtop" step="1" min="0"></div>
+                <div><label data-i18n="panel.dim.wBot">W Bot</label><input type="number" id="dim-wbot" step="1" min="0"></div>
+            </div>
+            <div class="input-row">
+                <div><label data-i18n="panel.dim.height">Height</label><input type="number" id="dim-fh" step="1" min="1"></div>
+                <div><label data-i18n="panel.dim.d">D</label><input type="number" id="dim-fd" step="1" min="1"></div>
+            </div>
+        </div>
     </div>
 
     <div id="pos-fields">
@@ -781,6 +791,10 @@ window.addEventListener('load', function() {
             'type.L-Bracket': 'L-Bracket',
             'type.Tapered Leg': 'Tapered Leg',
             'type.Tapered': 'Tapered',
+            'type.Frustum Board': 'Frustum Board',
+            'panel.dim.wTop': 'W Top',
+            'panel.dim.wBot': 'W Bot',
+            'tpl.frustumBoard': 'Frustum Board 60/100',
             'lang.label': 'Language'
         },
         de: {
@@ -935,6 +949,10 @@ window.addEventListener('load', function() {
             'type.L-Bracket': 'L-Winkel',
             'type.Tapered Leg': 'Konusbein',
             'type.Tapered': 'Konus',
+            'type.Frustum Board': 'Trapez-Brett',
+            'panel.dim.wTop': 'B oben',
+            'panel.dim.wBot': 'B unten',
+            'tpl.frustumBoard': 'Trapez-Brett 60/100',
             'lang.label': 'Sprache'
         }
     };
@@ -1523,6 +1541,52 @@ window.addEventListener('load', function() {
         return mesh;
     }
 
+    // Frustum Board: trapezoidal board with different widths at top and bottom.
+    // wBottom = width along +X at y=0, wTop = width along +X at y=h, d = depth (z), h = height.
+    // Both top and bottom faces are centered on x=0, z=0; mesh.position.y is set to h/2.
+    function frustumBoardGeometry(wTop, wBottom, h, d) {
+        var xtH = wTop / 2,    xbH = wBottom / 2;
+        var zH = d / 2;
+        var yT = h / 2,        yB = -h / 2;
+        // 8 corners: bottom 0..3 (CCW from -x,-z), top 4..7
+        var verts = new Float32Array([
+            -xbH, yB, -zH,   xbH, yB, -zH,   xbH, yB, zH,   -xbH, yB, zH, // bottom
+            -xtH, yT, -zH,   xtH, yT, -zH,   xtH, yT, zH,   -xtH, yT, zH  // top
+        ]);
+        // 12 triangles (2 per face × 6 faces): bottom, top, front(+z), back(-z), right(+x), left(-x)
+        var idx = [
+            0,2,1, 0,3,2,   // bottom (normal -y)
+            4,5,6, 4,6,7,   // top    (normal +y)
+            3,6,2, 3,7,6,   // front  (+z)
+            0,1,5, 0,5,4,   // back   (-z)
+            1,2,6, 1,6,5,   // right  (+x)
+            0,4,7, 0,7,3    // left   (-x)
+        ];
+        var geo = new THREE.BufferGeometry();
+        geo.setAttribute('position', new THREE.BufferAttribute(verts, 3));
+        geo.setIndex(idx);
+        geo.computeVertexNormals();
+        return geo;
+    }
+
+    function makeFrustumBoard(wTop, wBottom, h, d) {
+        wTop = (wTop !== undefined) ? wTop : 60;
+        wBottom = (wBottom !== undefined) ? wBottom : 100;
+        h = h || 80;
+        d = d || 40;
+        var geo = frustumBoardGeometry(wTop, wBottom, h, d);
+        var mesh = new THREE.Mesh(geo, createWoodMaterial());
+        mesh.castShadow = true;
+        mesh.receiveShadow = true;
+        mesh.position.y = h / 2;
+        mesh.userData = {
+            type: 'Frustum Board', id: ++pieceCounter,
+            wTop: wTop, wBottom: wBottom, h: h, d: d,
+            label: typeName('Frustum Board') + ' ' + pieceCounter, notches: 0, csgModified: false
+        };
+        return mesh;
+    }
+
     function makeTaperedLeg(rTop, rBottom, h) {
         rTop = rTop || 15; rBottom = rBottom || 25; h = h || 200;
         var geo = new THREE.CylinderGeometry(rTop, rBottom, h, 32);
@@ -1795,6 +1859,7 @@ window.addEventListener('load', function() {
 
     var dimWHD = document.getElementById('dim-whd');
     var dimRH = document.getElementById('dim-rh');
+    var dimFrustum = document.getElementById('dim-frustum');
     var dimTapered = document.getElementById('dim-tapered');
 
     var inputW = document.getElementById('dim-w');
@@ -1805,6 +1870,10 @@ window.addEventListener('load', function() {
     var inputRT = document.getElementById('dim-rt');
     var inputRB = document.getElementById('dim-rb');
     var inputTH = document.getElementById('dim-th');
+    var inputWTop = document.getElementById('dim-wtop');
+    var inputWBot = document.getElementById('dim-wbot');
+    var inputFH = document.getElementById('dim-fh');
+    var inputFD = document.getElementById('dim-fd');
 
     var inputPX = document.getElementById('pos-x');
     var inputPY = document.getElementById('pos-y');
@@ -1873,6 +1942,7 @@ window.addEventListener('load', function() {
         dimWHD.style.display = 'none';
         dimRH.style.display = 'none';
         dimTapered.style.display = 'none';
+        dimFrustum.style.display = 'none';
 
         if (type === 'Board' || type === 'Wedge' || type === 'L-Bracket') {
             dimWHD.style.display = 'block';
@@ -1888,6 +1958,12 @@ window.addEventListener('load', function() {
             inputRT.value = ud.rTop;
             inputRB.value = ud.rBottom;
             inputTH.value = ud.h;
+        } else if (type === 'Frustum Board') {
+            dimFrustum.style.display = 'block';
+            inputWTop.value = ud.wTop;
+            inputWBot.value = ud.wBottom;
+            inputFH.value = ud.h;
+            inputFD.value = ud.d;
         }
 
         inputPX.value = Math.round(mesh.position.x);
@@ -1917,6 +1993,8 @@ window.addEventListener('load', function() {
             text = 'R' + ud.r + ' x H' + ud.h + ' mm (' + t('summary.dia') + ' ' + (ud.r * 2) + ')';
         } else if (ud.type === 'Tapered Leg') {
             text = 'R' + ud.rTop + '/' + ud.rBottom + ' x H' + ud.h + ' mm';
+        } else if (ud.type === 'Frustum Board') {
+            text = ud.wTop + '/' + ud.wBottom + ' x ' + ud.h + ' x ' + ud.d + ' mm';
         }
         text += ' | ' + t('summary.notches') + ': ' + ud.notches;
         sizeSummary.textContent = text;
@@ -2043,6 +2121,8 @@ window.addEventListener('load', function() {
             newGeo.translate(-(bb.max.x + bb.min.x) / 2, -(bb.max.y + bb.min.y) / 2, -(bb.max.z + bb.min.z) / 2);
         } else if (ud.type === 'Tapered Leg') {
             newGeo = new THREE.CylinderGeometry(ud.rTop, ud.rBottom, ud.h, 32);
+        } else if (ud.type === 'Frustum Board') {
+            newGeo = frustumBoardGeometry(ud.wTop, ud.wBottom, ud.h, ud.d);
         }
         if (newGeo) {
             mesh.geometry = newGeo;
@@ -2070,6 +2150,11 @@ window.addEventListener('load', function() {
             ud.rTop = Math.max(1, parseFloat(inputRT.value) || 1);
             ud.rBottom = Math.max(1, parseFloat(inputRB.value) || 1);
             ud.h = Math.max(1, parseFloat(inputTH.value) || 1);
+        } else if (ud.type === 'Frustum Board') {
+            ud.wTop = Math.max(0, parseFloat(inputWTop.value) || 0);
+            ud.wBottom = Math.max(0, parseFloat(inputWBot.value) || 0);
+            ud.h = Math.max(1, parseFloat(inputFH.value) || 1);
+            ud.d = Math.max(1, parseFloat(inputFD.value) || 1);
         }
         rebuildGeometry(selectedPiece);
         updateSizeSummary();
@@ -2277,7 +2362,7 @@ window.addEventListener('load', function() {
         });
     }
 
-    [inputW, inputH, inputD, inputR, inputRHH, inputRT, inputRB, inputTH].forEach(function(inp) {
+    [inputW, inputH, inputD, inputR, inputRHH, inputRT, inputRB, inputTH, inputWTop, inputWBot, inputFH, inputFD].forEach(function(inp) {
         inp.addEventListener('change', onDimChange);
         bindEnter(inp, onDimChange);
     });
@@ -2403,6 +2488,8 @@ window.addEventListener('load', function() {
                 entry.r = ud.r; entry.h = ud.h;
             } else if (ud.type === 'Tapered Leg') {
                 entry.rTop = ud.rTop; entry.rBottom = ud.rBottom; entry.h = ud.h;
+            } else if (ud.type === 'Frustum Board') {
+                entry.wTop = ud.wTop; entry.wBottom = ud.wBottom; entry.h = ud.h; entry.d = ud.d;
             }
             if (ud.csgModified) {
                 if (Array.isArray(ud.csgOps) && ud.csgOps.length > 0) {
@@ -2454,6 +2541,7 @@ window.addEventListener('load', function() {
             if (spec.type === 'Wedge') return makeWedge(spec.w, spec.h, spec.d);
             if (spec.type === 'L-Bracket') return makeLBracket(spec.w, spec.h, spec.d);
             if (spec.type === 'Tapered Leg') return makeTaperedLeg(spec.rTop, spec.rBottom, spec.h);
+            if (spec.type === 'Frustum Board') return makeFrustumBoard(spec.wTop, spec.wBottom, spec.h, spec.d);
             return null;
         }
 
@@ -2474,6 +2562,7 @@ window.addEventListener('load', function() {
                 else if (entry.type === 'Wedge') mesh = makeWedge(entry.w, entry.h, entry.d);
                 else if (entry.type === 'L-Bracket') mesh = makeLBracket(entry.w, entry.h, entry.d);
                 else if (entry.type === 'Tapered Leg') mesh = makeTaperedLeg(entry.rTop, entry.rBottom, entry.h);
+                else if (entry.type === 'Frustum Board') mesh = makeFrustumBoard(entry.wTop, entry.wBottom, entry.h, entry.d);
                 pieceCounter--;
             }
             mesh.position.set(entry.px, entry.py, entry.pz);
@@ -2497,6 +2586,8 @@ window.addEventListener('load', function() {
                 mesh.userData.r = entry.r; mesh.userData.h = entry.h;
             } else if (entry.type === 'Tapered Leg') {
                 mesh.userData.rTop = entry.rTop; mesh.userData.rBottom = entry.rBottom; mesh.userData.h = entry.h;
+            } else if (entry.type === 'Frustum Board') {
+                mesh.userData.wTop = entry.wTop; mesh.userData.wBottom = entry.wBottom; mesh.userData.h = entry.h; mesh.userData.d = entry.d;
             }
             return mesh;
         }
@@ -2659,7 +2750,8 @@ window.addEventListener('load', function() {
         { nameKey: 'tpl.dowelRod10', type: 'Dowel',       r: 5, h: 300,  price: 1.50 },
         { nameKey: 'tpl.cornerBrace',type: 'L-Bracket',   w: 50, h: 50, d: 20,   price: 2.00 },
         { nameKey: 'tpl.tableLeg',   type: 'Tapered Leg', rTop: 20, rBottom: 30, h: 720, price: 12.00 },
-        { nameKey: 'tpl.doorWedge',  type: 'Wedge',       w: 80, h: 30, d: 40,   price: 1.00 }
+        { nameKey: 'tpl.doorWedge',  type: 'Wedge',       w: 80, h: 30, d: 40,   price: 1.00 },
+        { nameKey: 'tpl.frustumBoard', type: 'Frustum Board', wTop: 60, wBottom: 100, h: 80, d: 40, price: 3.00 }
     ];
 
     function loadCustomTemplates() {
@@ -2680,6 +2772,7 @@ window.addEventListener('load', function() {
         else if (tpl.type === 'Wedge') mesh = makeWedge(tpl.w, tpl.h, tpl.d);
         else if (tpl.type === 'L-Bracket') mesh = makeLBracket(tpl.w, tpl.h, tpl.d);
         else if (tpl.type === 'Tapered Leg') mesh = makeTaperedLeg(tpl.rTop, tpl.rBottom, tpl.h);
+        else if (tpl.type === 'Frustum Board') mesh = makeFrustumBoard(tpl.wTop, tpl.wBottom, tpl.h, tpl.d);
         if (mesh) {
             mesh.userData.label = (tpl.nameKey ? t(tpl.nameKey) : tpl.name) + ' ' + mesh.userData.id;
             mesh.userData.price = tpl.price || 0;
@@ -2700,6 +2793,8 @@ window.addEventListener('load', function() {
             tpl.r = ud.r; tpl.h = ud.h;
         } else if (ud.type === 'Tapered Leg') {
             tpl.rTop = ud.rTop; tpl.rBottom = ud.rBottom; tpl.h = ud.h;
+        } else if (ud.type === 'Frustum Board') {
+            tpl.wTop = ud.wTop; tpl.wBottom = ud.wBottom; tpl.h = ud.h; tpl.d = ud.d;
         }
         var custom = loadCustomTemplates();
         custom.push(tpl);
@@ -2763,6 +2858,8 @@ window.addEventListener('load', function() {
             return 'R' + tpl.r + ' H' + tpl.h;
         } else if (tpl.type === 'Tapered Leg') {
             return 'R' + tpl.rTop + '/' + tpl.rBottom + ' H' + tpl.h;
+        } else if (tpl.type === 'Frustum Board') {
+            return tpl.wTop + '/' + tpl.wBottom + ' x ' + tpl.h + ' x ' + tpl.d;
         }
         return '';
     }
@@ -3780,6 +3877,8 @@ window.addEventListener('load', function() {
                 row.push('', ud.h, '', ud.r * 2, ud.notches);
             } else if (ud.type === 'Tapered Leg') {
                 row.push('', ud.h, '', ud.rTop * 2 + '/' + ud.rBottom * 2, ud.notches);
+            } else if (ud.type === 'Frustum Board') {
+                row.push(ud.wTop + '/' + ud.wBottom, ud.h, ud.d, '', ud.notches);
             }
             row.push(groupLabel, currency + (ud.price || 0).toFixed(2), currency + cost.toFixed(2));
             rows.push(row);
@@ -4050,7 +4149,7 @@ window.addEventListener('load', function() {
     // Toolbar Button Handlers
     // ============================================================
 
-    var ADD_TYPES = ['Board', 'Dowel', 'Wedge', 'L-Bracket', 'Tapered Leg'];
+    var ADD_TYPES = ['Board', 'Frustum Board', 'Dowel', 'Wedge', 'L-Bracket', 'Tapered Leg'];
 
     function closeAllDropdowns() {
         var drops = document.querySelectorAll('.add-dropdown.open, .menu-dropdown.open');
@@ -4063,6 +4162,7 @@ window.addEventListener('load', function() {
         if (type === 'Wedge') return makeWedge();
         if (type === 'L-Bracket') return makeLBracket();
         if (type === 'Tapered Leg') return makeTaperedLeg();
+        if (type === 'Frustum Board') return makeFrustumBoard();
     }
 
 
@@ -4072,6 +4172,7 @@ window.addEventListener('load', function() {
         if (type === 'Wedge') return { type: 'Wedge', w: 80, h: 60, d: 40 };
         if (type === 'L-Bracket') return { type: 'L-Bracket', w: 60, h: 80, d: 20 };
         if (type === 'Tapered Leg') return { type: 'Tapered Leg', rTop: 15, rBottom: 25, h: 200 };
+        if (type === 'Frustum Board') return { type: 'Frustum Board', wTop: 60, wBottom: 100, h: 80, d: 40 };
         return {};
     }
 

--- a/index.html
+++ b/index.html
@@ -1548,30 +1548,32 @@ window.addEventListener('load', function() {
         var xtH = wTop / 2,    xbH = wBottom / 2;
         var zH = d / 2;
         var yT = h / 2,        yB = -h / 2;
-        // 8 corners: bottom 0..3 (CCW from -x,-z), top 4..7
-        var verts = new Float32Array([
-            -xbH, yB, -zH,   xbH, yB, -zH,   xbH, yB, zH,   -xbH, yB, zH, // bottom
-            -xtH, yT, -zH,   xtH, yT, -zH,   xtH, yT, zH,   -xtH, yT, zH  // top
+        // Mirror BoxGeometry's layout: 24 vertices (4 per face) so each face has its own
+        // normals (flat shading) and CSG sees clean per-face quads-as-triangles.
+        // Faces: bottom(-y), top(+y), front(+z), back(-z), right(+x), left(-x).
+        var positions = new Float32Array([
+            // bottom (-y): CCW from below
+            -xbH, yB, -zH,   xbH, yB, -zH,   xbH, yB, zH,   -xbH, yB, zH,
+            // top (+y): CCW from above
+            -xtH, yT, -zH,  -xtH, yT, zH,    xtH, yT, zH,    xtH, yT, -zH,
+            // front (+z): bottom-left, bottom-right, top-right, top-left
+            -xbH, yB, zH,    xbH, yB, zH,    xtH, yT, zH,   -xtH, yT, zH,
+            // back (-z): bottom-right, bottom-left, top-left, top-right (so CCW from -z)
+             xbH, yB, -zH,  -xbH, yB, -zH,  -xtH, yT, -zH,   xtH, yT, -zH,
+            // right (+x): bottom-front, bottom-back, top-back, top-front (CCW from +x)
+             xbH, yB,  zH,   xbH, yB, -zH,   xtH, yT, -zH,   xtH, yT,  zH,
+            // left (-x): bottom-back, bottom-front, top-front, top-back (CCW from -x)
+            -xbH, yB, -zH,  -xbH, yB,  zH,  -xtH, yT,  zH,  -xtH, yT, -zH
         ]);
-        // 12 triangles (2 per face × 6 faces). Winding chosen so that
-        // (v1-v0) × (v2-v0) points outward — verified per face.
-        // Verts: 0=(-,B,-), 1=(+,B,-), 2=(+,B,+), 3=(-,B,+); 4..7 same xz at y=+h/2.
-        var idx = [
-            0,1,2, 0,2,3,   // bottom (-y)
-            4,7,6, 4,6,5,   // top    (+y)
-            3,2,6, 3,6,7,   // front  (+z): 3=(-,B,+),2=(+,B,+),6=(+,T,+),7=(-,T,+)
-            1,0,4, 1,4,5,   // back   (-z): 1=(+,B,-),0=(-,B,-),4=(-,T,-),5=(+,T,-)
-            2,1,5, 2,5,6,   // right  (+x)
-            0,3,7, 0,7,4    // left   (-x)
-        ];
+        // Two triangles per face, indices into the 24-vertex array
+        var idx = [];
+        for (var f = 0; f < 6; f++) {
+            var b = f * 4;
+            idx.push(b, b+1, b+2,  b, b+2, b+3);
+        }
         var geo = new THREE.BufferGeometry();
-        geo.setAttribute('position', new THREE.BufferAttribute(verts, 3));
+        geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
         geo.setIndex(idx);
-        // Convert to non-indexed before computing normals so each face gets its own
-        // vertex normals (flat shading) — matches BoxGeometry's look. With shared
-        // vertices the averaged normals make faces appear darker/smoother than the
-        // surrounding Boards, which use BoxGeometry (already flat-shaded).
-        geo = geo.toNonIndexed();
         geo.computeVertexNormals();
         return geo;
     }

--- a/index.html
+++ b/index.html
@@ -1548,31 +1548,58 @@ window.addEventListener('load', function() {
         var xtH = wTop / 2,    xbH = wBottom / 2;
         var zH = d / 2;
         var yT = h / 2,        yB = -h / 2;
-        // Mirror BoxGeometry's layout: 24 vertices (4 per face) so each face has its own
-        // normals (flat shading) and CSG sees clean per-face quads-as-triangles.
-        // Faces: bottom(-y), top(+y), front(+z), back(-z), right(+x), left(-x).
-        var positions = new Float32Array([
-            // bottom (-y): CCW from below
-            -xbH, yB, -zH,   xbH, yB, -zH,   xbH, yB, zH,   -xbH, yB, zH,
-            // top (+y): CCW from above
-            -xtH, yT, -zH,  -xtH, yT, zH,    xtH, yT, zH,    xtH, yT, -zH,
-            // front (+z): bottom-left, bottom-right, top-right, top-left
-            -xbH, yB, zH,    xbH, yB, zH,    xtH, yT, zH,   -xtH, yT, zH,
-            // back (-z): bottom-right, bottom-left, top-left, top-right (so CCW from -z)
-             xbH, yB, -zH,  -xbH, yB, -zH,  -xtH, yT, -zH,   xtH, yT, -zH,
-            // right (+x): bottom-front, bottom-back, top-back, top-front (CCW from +x)
-             xbH, yB,  zH,   xbH, yB, -zH,   xtH, yT, -zH,   xtH, yT,  zH,
-            // left (-x): bottom-back, bottom-front, top-front, top-back (CCW from -x)
-            -xbH, yB, -zH,  -xbH, yB,  zH,  -xtH, yT,  zH,  -xtH, yT, -zH
-        ]);
-        // Two triangles per face, indices into the 24-vertex array
+        // Build per-face vertex lists. Each face contributes either a quad (4 verts, 2 tris)
+        // or a triangle (3 verts, 1 tri) when one edge collapses (wTop=0 or wBottom=0).
+        // Degenerate faces (zero area) are skipped entirely.
+        var positions = [];
         var idx = [];
-        for (var f = 0; f < 6; f++) {
-            var b = f * 4;
-            idx.push(b, b+1, b+2,  b, b+2, b+3);
+        function addFace(verts) {
+            if (verts.length < 3) return;
+            // De-duplicate consecutive identical vertices (handles wTop=0 etc).
+            var clean = [];
+            for (var i = 0; i < verts.length; i++) {
+                var a = verts[i], b = verts[(i + 1) % verts.length];
+                if (a[0] !== b[0] || a[1] !== b[1] || a[2] !== b[2]) clean.push(a);
+            }
+            if (clean.length < 3) return;
+            // Reject degenerate (zero-area / colinear) faces — would give CSG a zero normal.
+            var v0 = clean[0], v1 = clean[1], v2 = clean[2];
+            var ax = v1[0]-v0[0], ay = v1[1]-v0[1], az = v1[2]-v0[2];
+            var bx = v2[0]-v0[0], by = v2[1]-v0[1], bz = v2[2]-v0[2];
+            var nx = ay*bz - az*by, ny = az*bx - ax*bz, nz = ax*by - ay*bx;
+            if (nx*nx + ny*ny + nz*nz < 1e-10) return;
+            var base = positions.length / 3;
+            clean.forEach(function(v) { positions.push(v[0], v[1], v[2]); });
+            for (var k = 2; k < clean.length; k++) {
+                idx.push(base, base + k - 1, base + k);
+            }
         }
+        // bottom (-y): CCW from below
+        addFace([
+            [-xbH, yB, -zH], [ xbH, yB, -zH], [ xbH, yB,  zH], [-xbH, yB,  zH]
+        ]);
+        // top (+y): CCW from above
+        addFace([
+            [-xtH, yT, -zH], [-xtH, yT,  zH], [ xtH, yT,  zH], [ xtH, yT, -zH]
+        ]);
+        // front (+z)
+        addFace([
+            [-xbH, yB,  zH], [ xbH, yB,  zH], [ xtH, yT,  zH], [-xtH, yT,  zH]
+        ]);
+        // back (-z)
+        addFace([
+            [ xbH, yB, -zH], [-xbH, yB, -zH], [-xtH, yT, -zH], [ xtH, yT, -zH]
+        ]);
+        // right (+x)
+        addFace([
+            [ xbH, yB,  zH], [ xbH, yB, -zH], [ xtH, yT, -zH], [ xtH, yT,  zH]
+        ]);
+        // left (-x)
+        addFace([
+            [-xbH, yB, -zH], [-xbH, yB,  zH], [-xtH, yT,  zH], [-xtH, yT, -zH]
+        ]);
         var geo = new THREE.BufferGeometry();
-        geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+        geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
         geo.setIndex(idx);
         geo.computeVertexNormals();
         return geo;

--- a/index.html
+++ b/index.html
@@ -1553,18 +1553,25 @@ window.addEventListener('load', function() {
             -xbH, yB, -zH,   xbH, yB, -zH,   xbH, yB, zH,   -xbH, yB, zH, // bottom
             -xtH, yT, -zH,   xtH, yT, -zH,   xtH, yT, zH,   -xtH, yT, zH  // top
         ]);
-        // 12 triangles (2 per face × 6 faces): bottom, top, front(+z), back(-z), right(+x), left(-x)
+        // 12 triangles (2 per face × 6 faces). Winding chosen so that
+        // (v1-v0) × (v2-v0) points outward — verified per face.
+        // Verts: 0=(-,B,-), 1=(+,B,-), 2=(+,B,+), 3=(-,B,+); 4..7 same xz at y=+h/2.
         var idx = [
-            0,2,1, 0,3,2,   // bottom (normal -y)
-            4,5,6, 4,6,7,   // top    (normal +y)
-            3,6,2, 3,7,6,   // front  (+z)
-            0,1,5, 0,5,4,   // back   (-z)
-            1,2,6, 1,6,5,   // right  (+x)
-            0,4,7, 0,7,3    // left   (-x)
+            0,1,2, 0,2,3,   // bottom (-y)
+            4,7,6, 4,6,5,   // top    (+y)
+            3,2,6, 3,6,7,   // front  (+z): 3=(-,B,+),2=(+,B,+),6=(+,T,+),7=(-,T,+)
+            1,0,4, 1,4,5,   // back   (-z): 1=(+,B,-),0=(-,B,-),4=(-,T,-),5=(+,T,-)
+            2,1,5, 2,5,6,   // right  (+x)
+            0,3,7, 0,7,4    // left   (-x)
         ];
         var geo = new THREE.BufferGeometry();
         geo.setAttribute('position', new THREE.BufferAttribute(verts, 3));
         geo.setIndex(idx);
+        // Convert to non-indexed before computing normals so each face gets its own
+        // vertex normals (flat shading) — matches BoxGeometry's look. With shared
+        // vertices the averaged normals make faces appear darker/smoother than the
+        // surrounding Boards, which use BoxGeometry (already flat-shaded).
+        geo = geo.toNonIndexed();
         geo.computeVertexNormals();
         return geo;
     }

--- a/woodmodel.schema.json
+++ b/woodmodel.schema.json
@@ -35,7 +35,7 @@
           "type": {
             "description": "Fixed English identifier for the piece shape. Never translated; used as a discriminator for dimension fields.",
             "type": "string",
-            "enum": ["Board", "Dowel", "Wedge", "L-Bracket", "Tapered Leg"]
+            "enum": ["Board", "Dowel", "Wedge", "L-Bracket", "Tapered Leg", "Frustum Board"]
           },
 
           "id": {
@@ -130,6 +130,14 @@
             "description": "Bottom radius in mm. Required for Tapered Leg.",
             "type": "number", "exclusiveMinimum": 0
           },
+          "wTop": {
+            "description": "Top width in mm. Required for Frustum Board (may be 0 for a wedge-like collapse).",
+            "type": "number", "minimum": 0
+          },
+          "wBottom": {
+            "description": "Bottom width in mm. Required for Frustum Board (may be 0).",
+            "type": "number", "minimum": 0
+          },
 
           "geoPositions": {
             "description": "Legacy: flat array of vertex XYZ coordinates for CSG-modified geometry (BufferGeometry position attribute). Used for files saved before declarative csgOps existed. New saves use csgOps instead.",
@@ -161,7 +169,7 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["Board", "Dowel", "Wedge", "L-Bracket", "Tapered Leg"]
+                      "enum": ["Board", "Dowel", "Wedge", "L-Bracket", "Tapered Leg", "Frustum Board"]
                     },
                     "px": { "type": "number" },
                     "py": { "type": "number" },
@@ -174,7 +182,9 @@
                     "d": { "type": "number", "exclusiveMinimum": 0 },
                     "r": { "type": "number", "exclusiveMinimum": 0 },
                     "rTop": { "type": "number", "exclusiveMinimum": 0 },
-                    "rBottom": { "type": "number", "exclusiveMinimum": 0 }
+                    "rBottom": { "type": "number", "exclusiveMinimum": 0 },
+                    "wTop": { "type": "number", "minimum": 0 },
+                    "wBottom": { "type": "number", "minimum": 0 }
                   }
                 }
               }

--- a/woodtemplates.schema.json
+++ b/woodtemplates.schema.json
@@ -23,7 +23,7 @@
       "type": {
         "description": "Piece shape. Must match one of the fixed English identifiers used in the app.",
         "type": "string",
-        "enum": ["Board", "Dowel", "Wedge", "L-Bracket", "Tapered Leg"]
+        "enum": ["Board", "Dowel", "Wedge", "L-Bracket", "Tapered Leg", "Frustum Board"]
       },
 
       "price": {
@@ -55,6 +55,14 @@
       "rBottom": {
         "description": "Bottom radius in mm. Required for Tapered Leg.",
         "type": "number", "exclusiveMinimum": 0
+      },
+      "wTop": {
+        "description": "Top width in mm. Required for Frustum Board.",
+        "type": "number", "minimum": 0
+      },
+      "wBottom": {
+        "description": "Bottom width in mm. Required for Frustum Board.",
+        "type": "number", "minimum": 0
       }
     },
 
@@ -78,6 +86,10 @@
       {
         "if": { "properties": { "type": { "const": "Tapered Leg" } } },
         "then": { "required": ["rTop", "rBottom", "h"] }
+      },
+      {
+        "if": { "properties": { "type": { "const": "Frustum Board" } } },
+        "then": { "required": ["wTop", "wBottom", "h", "d"] }
       }
     ]
   },


### PR DESCRIPTION
Closes #19. **Stacked on top of #26** — base branch is \`feature/camera-pivot-focus\`. Once #26 lands on \`main\`, GitHub will auto-rebase this PR and the base will become \`main\`.

## Summary
- New \`Frustum Board\` primitive (trapezoidal — different widths at top and bottom along x).
- Parameters: \`wTop\`, \`wBottom\`, \`h\`, \`d\`. \`wTop\`/\`wBottom\` may be 0 (face collapses to an edge).
- Hand-built BufferGeometry (\`frustumBoardGeometry\`) — 8 vertices, 12 triangles, both faces centered on y axis so rotation/snap match a regular Board.
- Wired through every code path that branches on \`userData.type\`: shape factory, rebuild, serialize/restore, templates, default dims, mega-menu, side panel, size summary, CSV export.
- Built-in template \`tpl.frustumBoard\` (60 / 100 × 80 × 40, 3.00 €) with en + de translations.
- JSON schemas (\`woodmodel.schema.json\`, \`woodtemplates.schema.json\`) updated.

## Test plan
- [x] \`+ Add → Frustum Board → Default\` adds a piece with W Top 60 / W Bot 100 / H 80 / D 40; visual is a trapezoid.
- [x] Edit \`W Top\` to 0 — top face collapses to an edge (wedge-like) with no normal artefacts.
- [x] Save the model, reload — the piece returns identical.
- [x] Apply a Cut Joint that subtracts a Dowel from a Frustum Board, save and reload — declarative csgOps replay works (the Frustum Board is the base, Dowel is the tool).
- [x] Export CSV — Frustum Board row shows \`wTop/wBottom\` in the W column, height and depth filled.
- [x] Switch language to DE — type label "Trapez-Brett" + field labels "B oben/B unten" appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)