### PR TITLE
Pyramid Frustum primitive (#20)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Everything runs inside a `window.addEventListener('load', ...)` closure in `inde
 
 3. **Application State** — Global mutable state: `pieces[]` array, selection state, mode flags (snap, cut, overlap), undo/redo stacks.
 
-4. **Shape Factory** — `makeBoard`, `makeDowel`, `makeWedge`, `makeLBracket`, `makeTaperedLeg`, `makeFrustumBoard`. Each returns a Three.js Mesh with a `userData` object storing type and dimensions. `addPiece()` registers meshes into the scene and `pieces[]`. The Frustum Board (`type: 'Frustum Board'`) is a hand-built BufferGeometry built by `frustumBoardGeometry(wTop, wBottom, h, d)` — 8 vertices, 12 triangles; top and bottom faces are both centered on the y axis. `wTop`/`wBottom` may be 0 (collapses to a wedge).
+4. **Shape Factory** — `makeBoard`, `makeDowel`, `makeWedge`, `makeLBracket`, `makeTaperedLeg`, `makeFrustumBoard`, `makePyramidFrustum`. Each returns a Three.js Mesh with a `userData` object storing type and dimensions. `addPiece()` registers meshes into the scene and `pieces[]`. The Frustum Board (`type: 'Frustum Board'`) is a hand-built BufferGeometry built by `frustumBoardGeometry(wTop, wBottom, h, d)`. The Pyramid Frustum (`type: 'Pyramid Frustum'`) is built by `pyramidFrustumGeometry(wTop, dTop, wBottom, dBottom, h)` — same 8-vertex / 12-triangle topology, but top and bottom faces have independent rectangular dimensions (set `wTop=dTop=0` for a true pyramid). Both primitives center their top and bottom faces on the y axis.
 
 5. **Label System** — 3D sprite labels positioned above pieces using canvas-rendered textures.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A browser-based 3D woodworking modeller for planning and visualizing wooden cons
 
 ## Features
 
-- **6 shape types**: Board, Frustum Board (trapezoidal — different widths at top and bottom), Dowel, Wedge, L-Bracket, and Tapered Leg
+- **7 shape types**: Board, Frustum Board (trapezoidal — different widths at top and bottom), Pyramid Frustum (4-sided — independent W/D at top and bottom; collapses to a true pyramid when top = 0), Dowel, Wedge, L-Bracket, and Tapered Leg
 - **Interactive 3D viewport** with orbit controls (pan, rotate, zoom); double-click a piece to set the orbit pivot, double-click empty space to recenter on the whole model, or press `F` to focus the current selection
 - **Real-time editing** of dimensions, position, and rotation via the side panel
 - **Drag-to-move** pieces directly in the viewport (Shift+drag for vertical movement)

--- a/index.html
+++ b/index.html
@@ -509,6 +509,19 @@
                 <div><label data-i18n="panel.dim.d">D</label><input type="number" id="dim-fd" step="1" min="1"></div>
             </div>
         </div>
+        <div id="dim-pyramid" style="display:none">
+            <div class="input-row">
+                <div><label data-i18n="panel.dim.wTop">W Top</label><input type="number" id="dim-pwtop" step="1" min="0"></div>
+                <div><label data-i18n="panel.dim.dTop">D Top</label><input type="number" id="dim-pdtop" step="1" min="0"></div>
+            </div>
+            <div class="input-row">
+                <div><label data-i18n="panel.dim.wBot">W Bot</label><input type="number" id="dim-pwbot" step="1" min="0"></div>
+                <div><label data-i18n="panel.dim.dBot">D Bot</label><input type="number" id="dim-pdbot" step="1" min="0"></div>
+            </div>
+            <div class="input-row">
+                <div><label data-i18n="panel.dim.height">Height</label><input type="number" id="dim-ph" step="1" min="1"></div>
+            </div>
+        </div>
     </div>
 
     <div id="pos-fields">
@@ -792,9 +805,14 @@ window.addEventListener('load', function() {
             'type.Tapered Leg': 'Tapered Leg',
             'type.Tapered': 'Tapered',
             'type.Frustum Board': 'Frustum Board',
+            'type.Pyramid Frustum': 'Pyramid Frustum',
             'panel.dim.wTop': 'W Top',
             'panel.dim.wBot': 'W Bot',
+            'panel.dim.dTop': 'D Top',
+            'panel.dim.dBot': 'D Bot',
             'tpl.frustumBoard': 'Frustum Board 60/100',
+            'tpl.pyramidRoof': 'Pyramid Roof 100/40',
+            'tpl.pyramid': 'Pyramid 100→0',
             'lang.label': 'Language'
         },
         de: {
@@ -950,9 +968,14 @@ window.addEventListener('load', function() {
             'type.Tapered Leg': 'Konusbein',
             'type.Tapered': 'Konus',
             'type.Frustum Board': 'Trapez-Brett',
+            'type.Pyramid Frustum': 'Pyramidenstumpf',
             'panel.dim.wTop': 'B oben',
             'panel.dim.wBot': 'B unten',
+            'panel.dim.dTop': 'T oben',
+            'panel.dim.dBot': 'T unten',
             'tpl.frustumBoard': 'Trapez-Brett 60/100',
+            'tpl.pyramidRoof': 'Pyramidendach 100/40',
+            'tpl.pyramid': 'Pyramide 100→0',
             'lang.label': 'Sprache'
         }
     };
@@ -1574,6 +1597,52 @@ window.addEventListener('load', function() {
         return geo;
     }
 
+    // Pyramid Frustum: 4-sided frustum centered on x=0, z=0; both top and bottom faces are axis-aligned rectangles.
+    // wTop=dTop=0 collapses the top to a point (true pyramid). wBottom=dBottom=0 collapses the bottom.
+    function pyramidFrustumGeometry(wTop, dTop, wBottom, dBottom, h) {
+        var xtH = wTop / 2,    ztH = dTop / 2;
+        var xbH = wBottom / 2, zbH = dBottom / 2;
+        var yT = h / 2,        yB = -h / 2;
+        var verts = new Float32Array([
+            -xbH, yB, -zbH,   xbH, yB, -zbH,   xbH, yB, zbH,   -xbH, yB, zbH,
+            -xtH, yT, -ztH,   xtH, yT, -ztH,   xtH, yT, ztH,   -xtH, yT, ztH
+        ]);
+        var idx = [
+            0,2,1, 0,3,2,
+            4,5,6, 4,6,7,
+            3,6,2, 3,7,6,
+            0,1,5, 0,5,4,
+            1,2,6, 1,6,5,
+            0,4,7, 0,7,3
+        ];
+        var geo = new THREE.BufferGeometry();
+        geo.setAttribute('position', new THREE.BufferAttribute(verts, 3));
+        geo.setIndex(idx);
+        // Flat shading via toNonIndexed() — see frustumBoardGeometry for the rationale.
+        geo = geo.toNonIndexed();
+        geo.computeVertexNormals();
+        return geo;
+    }
+
+    function makePyramidFrustum(wTop, dTop, wBottom, dBottom, h) {
+        wTop = (wTop !== undefined) ? wTop : 40;
+        dTop = (dTop !== undefined) ? dTop : 40;
+        wBottom = (wBottom !== undefined) ? wBottom : 100;
+        dBottom = (dBottom !== undefined) ? dBottom : 100;
+        h = h || 80;
+        var geo = pyramidFrustumGeometry(wTop, dTop, wBottom, dBottom, h);
+        var mesh = new THREE.Mesh(geo, createWoodMaterial());
+        mesh.castShadow = true;
+        mesh.receiveShadow = true;
+        mesh.position.y = h / 2;
+        mesh.userData = {
+            type: 'Pyramid Frustum', id: ++pieceCounter,
+            wTop: wTop, dTop: dTop, wBottom: wBottom, dBottom: dBottom, h: h,
+            label: typeName('Pyramid Frustum') + ' ' + pieceCounter, notches: 0, csgModified: false
+        };
+        return mesh;
+    }
+
     function makeFrustumBoard(wTop, wBottom, h, d) {
         wTop = (wTop !== undefined) ? wTop : 60;
         wBottom = (wBottom !== undefined) ? wBottom : 100;
@@ -1865,6 +1934,7 @@ window.addEventListener('load', function() {
     var dimWHD = document.getElementById('dim-whd');
     var dimRH = document.getElementById('dim-rh');
     var dimFrustum = document.getElementById('dim-frustum');
+    var dimPyramid = document.getElementById('dim-pyramid');
     var dimTapered = document.getElementById('dim-tapered');
 
     var inputW = document.getElementById('dim-w');
@@ -1879,6 +1949,11 @@ window.addEventListener('load', function() {
     var inputWBot = document.getElementById('dim-wbot');
     var inputFH = document.getElementById('dim-fh');
     var inputFD = document.getElementById('dim-fd');
+    var inputPWTop = document.getElementById('dim-pwtop');
+    var inputPDTop = document.getElementById('dim-pdtop');
+    var inputPWBot = document.getElementById('dim-pwbot');
+    var inputPDBot = document.getElementById('dim-pdbot');
+    var inputPH = document.getElementById('dim-ph');
 
     var inputPX = document.getElementById('pos-x');
     var inputPY = document.getElementById('pos-y');
@@ -1948,6 +2023,7 @@ window.addEventListener('load', function() {
         dimRH.style.display = 'none';
         dimTapered.style.display = 'none';
         dimFrustum.style.display = 'none';
+        dimPyramid.style.display = 'none';
 
         if (type === 'Board' || type === 'Wedge' || type === 'L-Bracket') {
             dimWHD.style.display = 'block';
@@ -1969,6 +2045,13 @@ window.addEventListener('load', function() {
             inputWBot.value = ud.wBottom;
             inputFH.value = ud.h;
             inputFD.value = ud.d;
+        } else if (type === 'Pyramid Frustum') {
+            dimPyramid.style.display = 'block';
+            inputPWTop.value = ud.wTop;
+            inputPDTop.value = ud.dTop;
+            inputPWBot.value = ud.wBottom;
+            inputPDBot.value = ud.dBottom;
+            inputPH.value = ud.h;
         }
 
         inputPX.value = Math.round(mesh.position.x);
@@ -2000,6 +2083,8 @@ window.addEventListener('load', function() {
             text = 'R' + ud.rTop + '/' + ud.rBottom + ' x H' + ud.h + ' mm';
         } else if (ud.type === 'Frustum Board') {
             text = ud.wTop + '/' + ud.wBottom + ' x ' + ud.h + ' x ' + ud.d + ' mm';
+        } else if (ud.type === 'Pyramid Frustum') {
+            text = ud.wTop + 'x' + ud.dTop + ' / ' + ud.wBottom + 'x' + ud.dBottom + ' x H' + ud.h + ' mm';
         }
         text += ' | ' + t('summary.notches') + ': ' + ud.notches;
         sizeSummary.textContent = text;
@@ -2128,6 +2213,8 @@ window.addEventListener('load', function() {
             newGeo = new THREE.CylinderGeometry(ud.rTop, ud.rBottom, ud.h, 32);
         } else if (ud.type === 'Frustum Board') {
             newGeo = frustumBoardGeometry(ud.wTop, ud.wBottom, ud.h, ud.d);
+        } else if (ud.type === 'Pyramid Frustum') {
+            newGeo = pyramidFrustumGeometry(ud.wTop, ud.dTop, ud.wBottom, ud.dBottom, ud.h);
         }
         if (newGeo) {
             mesh.geometry = newGeo;
@@ -2160,6 +2247,12 @@ window.addEventListener('load', function() {
             ud.wBottom = Math.max(0, parseFloat(inputWBot.value) || 0);
             ud.h = Math.max(1, parseFloat(inputFH.value) || 1);
             ud.d = Math.max(1, parseFloat(inputFD.value) || 1);
+        } else if (ud.type === 'Pyramid Frustum') {
+            ud.wTop = Math.max(0, parseFloat(inputPWTop.value) || 0);
+            ud.dTop = Math.max(0, parseFloat(inputPDTop.value) || 0);
+            ud.wBottom = Math.max(0, parseFloat(inputPWBot.value) || 0);
+            ud.dBottom = Math.max(0, parseFloat(inputPDBot.value) || 0);
+            ud.h = Math.max(1, parseFloat(inputPH.value) || 1);
         }
         rebuildGeometry(selectedPiece);
         updateSizeSummary();
@@ -2367,7 +2460,7 @@ window.addEventListener('load', function() {
         });
     }
 
-    [inputW, inputH, inputD, inputR, inputRHH, inputRT, inputRB, inputTH, inputWTop, inputWBot, inputFH, inputFD].forEach(function(inp) {
+    [inputW, inputH, inputD, inputR, inputRHH, inputRT, inputRB, inputTH, inputWTop, inputWBot, inputFH, inputFD, inputPWTop, inputPDTop, inputPWBot, inputPDBot, inputPH].forEach(function(inp) {
         inp.addEventListener('change', onDimChange);
         bindEnter(inp, onDimChange);
     });
@@ -2495,6 +2588,9 @@ window.addEventListener('load', function() {
                 entry.rTop = ud.rTop; entry.rBottom = ud.rBottom; entry.h = ud.h;
             } else if (ud.type === 'Frustum Board') {
                 entry.wTop = ud.wTop; entry.wBottom = ud.wBottom; entry.h = ud.h; entry.d = ud.d;
+            } else if (ud.type === 'Pyramid Frustum') {
+                entry.wTop = ud.wTop; entry.dTop = ud.dTop;
+                entry.wBottom = ud.wBottom; entry.dBottom = ud.dBottom; entry.h = ud.h;
             }
             if (ud.csgModified) {
                 if (Array.isArray(ud.csgOps) && ud.csgOps.length > 0) {
@@ -2547,6 +2643,7 @@ window.addEventListener('load', function() {
             if (spec.type === 'L-Bracket') return makeLBracket(spec.w, spec.h, spec.d);
             if (spec.type === 'Tapered Leg') return makeTaperedLeg(spec.rTop, spec.rBottom, spec.h);
             if (spec.type === 'Frustum Board') return makeFrustumBoard(spec.wTop, spec.wBottom, spec.h, spec.d);
+            if (spec.type === 'Pyramid Frustum') return makePyramidFrustum(spec.wTop, spec.dTop, spec.wBottom, spec.dBottom, spec.h);
             return null;
         }
 
@@ -2568,6 +2665,7 @@ window.addEventListener('load', function() {
                 else if (entry.type === 'L-Bracket') mesh = makeLBracket(entry.w, entry.h, entry.d);
                 else if (entry.type === 'Tapered Leg') mesh = makeTaperedLeg(entry.rTop, entry.rBottom, entry.h);
                 else if (entry.type === 'Frustum Board') mesh = makeFrustumBoard(entry.wTop, entry.wBottom, entry.h, entry.d);
+                else if (entry.type === 'Pyramid Frustum') mesh = makePyramidFrustum(entry.wTop, entry.dTop, entry.wBottom, entry.dBottom, entry.h);
                 pieceCounter--;
             }
             mesh.position.set(entry.px, entry.py, entry.pz);
@@ -2593,6 +2691,9 @@ window.addEventListener('load', function() {
                 mesh.userData.rTop = entry.rTop; mesh.userData.rBottom = entry.rBottom; mesh.userData.h = entry.h;
             } else if (entry.type === 'Frustum Board') {
                 mesh.userData.wTop = entry.wTop; mesh.userData.wBottom = entry.wBottom; mesh.userData.h = entry.h; mesh.userData.d = entry.d;
+            } else if (entry.type === 'Pyramid Frustum') {
+                mesh.userData.wTop = entry.wTop; mesh.userData.dTop = entry.dTop;
+                mesh.userData.wBottom = entry.wBottom; mesh.userData.dBottom = entry.dBottom; mesh.userData.h = entry.h;
             }
             return mesh;
         }
@@ -2756,7 +2857,9 @@ window.addEventListener('load', function() {
         { nameKey: 'tpl.cornerBrace',type: 'L-Bracket',   w: 50, h: 50, d: 20,   price: 2.00 },
         { nameKey: 'tpl.tableLeg',   type: 'Tapered Leg', rTop: 20, rBottom: 30, h: 720, price: 12.00 },
         { nameKey: 'tpl.doorWedge',  type: 'Wedge',       w: 80, h: 30, d: 40,   price: 1.00 },
-        { nameKey: 'tpl.frustumBoard', type: 'Frustum Board', wTop: 60, wBottom: 100, h: 80, d: 40, price: 3.00 }
+        { nameKey: 'tpl.frustumBoard', type: 'Frustum Board', wTop: 60, wBottom: 100, h: 80, d: 40, price: 3.00 },
+        { nameKey: 'tpl.pyramidRoof', type: 'Pyramid Frustum', wTop: 40, dTop: 40, wBottom: 100, dBottom: 100, h: 60, price: 5.00 },
+        { nameKey: 'tpl.pyramid',     type: 'Pyramid Frustum', wTop: 0,  dTop: 0,  wBottom: 100, dBottom: 100, h: 80, price: 4.00 }
     ];
 
     function loadCustomTemplates() {
@@ -2778,6 +2881,7 @@ window.addEventListener('load', function() {
         else if (tpl.type === 'L-Bracket') mesh = makeLBracket(tpl.w, tpl.h, tpl.d);
         else if (tpl.type === 'Tapered Leg') mesh = makeTaperedLeg(tpl.rTop, tpl.rBottom, tpl.h);
         else if (tpl.type === 'Frustum Board') mesh = makeFrustumBoard(tpl.wTop, tpl.wBottom, tpl.h, tpl.d);
+        else if (tpl.type === 'Pyramid Frustum') mesh = makePyramidFrustum(tpl.wTop, tpl.dTop, tpl.wBottom, tpl.dBottom, tpl.h);
         if (mesh) {
             mesh.userData.label = (tpl.nameKey ? t(tpl.nameKey) : tpl.name) + ' ' + mesh.userData.id;
             mesh.userData.price = tpl.price || 0;
@@ -2800,6 +2904,9 @@ window.addEventListener('load', function() {
             tpl.rTop = ud.rTop; tpl.rBottom = ud.rBottom; tpl.h = ud.h;
         } else if (ud.type === 'Frustum Board') {
             tpl.wTop = ud.wTop; tpl.wBottom = ud.wBottom; tpl.h = ud.h; tpl.d = ud.d;
+        } else if (ud.type === 'Pyramid Frustum') {
+            tpl.wTop = ud.wTop; tpl.dTop = ud.dTop;
+            tpl.wBottom = ud.wBottom; tpl.dBottom = ud.dBottom; tpl.h = ud.h;
         }
         var custom = loadCustomTemplates();
         custom.push(tpl);
@@ -2865,6 +2972,8 @@ window.addEventListener('load', function() {
             return 'R' + tpl.rTop + '/' + tpl.rBottom + ' H' + tpl.h;
         } else if (tpl.type === 'Frustum Board') {
             return tpl.wTop + '/' + tpl.wBottom + ' x ' + tpl.h + ' x ' + tpl.d;
+        } else if (tpl.type === 'Pyramid Frustum') {
+            return tpl.wTop + 'x' + tpl.dTop + '/' + tpl.wBottom + 'x' + tpl.dBottom + ' H' + tpl.h;
         }
         return '';
     }
@@ -3884,6 +3993,8 @@ window.addEventListener('load', function() {
                 row.push('', ud.h, '', ud.rTop * 2 + '/' + ud.rBottom * 2, ud.notches);
             } else if (ud.type === 'Frustum Board') {
                 row.push(ud.wTop + '/' + ud.wBottom, ud.h, ud.d, '', ud.notches);
+            } else if (ud.type === 'Pyramid Frustum') {
+                row.push(ud.wTop + '/' + ud.wBottom, ud.h, ud.dTop + '/' + ud.dBottom, '', ud.notches);
             }
             row.push(groupLabel, currency + (ud.price || 0).toFixed(2), currency + cost.toFixed(2));
             rows.push(row);
@@ -4154,7 +4265,7 @@ window.addEventListener('load', function() {
     // Toolbar Button Handlers
     // ============================================================
 
-    var ADD_TYPES = ['Board', 'Frustum Board', 'Dowel', 'Wedge', 'L-Bracket', 'Tapered Leg'];
+    var ADD_TYPES = ['Board', 'Frustum Board', 'Pyramid Frustum', 'Dowel', 'Wedge', 'L-Bracket', 'Tapered Leg'];
 
     function closeAllDropdowns() {
         var drops = document.querySelectorAll('.add-dropdown.open, .menu-dropdown.open');
@@ -4168,6 +4279,7 @@ window.addEventListener('load', function() {
         if (type === 'L-Bracket') return makeLBracket();
         if (type === 'Tapered Leg') return makeTaperedLeg();
         if (type === 'Frustum Board') return makeFrustumBoard();
+        if (type === 'Pyramid Frustum') return makePyramidFrustum();
     }
 
 
@@ -4178,6 +4290,7 @@ window.addEventListener('load', function() {
         if (type === 'L-Bracket') return { type: 'L-Bracket', w: 60, h: 80, d: 20 };
         if (type === 'Tapered Leg') return { type: 'Tapered Leg', rTop: 15, rBottom: 25, h: 200 };
         if (type === 'Frustum Board') return { type: 'Frustum Board', wTop: 60, wBottom: 100, h: 80, d: 40 };
+        if (type === 'Pyramid Frustum') return { type: 'Pyramid Frustum', wTop: 40, dTop: 40, wBottom: 100, dBottom: 100, h: 80 };
         return {};
     }
 

--- a/index.html
+++ b/index.html
@@ -1565,6 +1565,11 @@ window.addEventListener('load', function() {
         var geo = new THREE.BufferGeometry();
         geo.setAttribute('position', new THREE.BufferAttribute(verts, 3));
         geo.setIndex(idx);
+        // Convert to non-indexed before computing normals so each face gets its own
+        // vertex normals (flat shading) — matches BoxGeometry's look. With shared
+        // vertices the averaged normals make faces appear darker/smoother than the
+        // surrounding Boards, which use BoxGeometry (already flat-shaded).
+        geo = geo.toNonIndexed();
         geo.computeVertexNormals();
         return geo;
     }

--- a/woodmodel.schema.json
+++ b/woodmodel.schema.json
@@ -35,7 +35,7 @@
           "type": {
             "description": "Fixed English identifier for the piece shape. Never translated; used as a discriminator for dimension fields.",
             "type": "string",
-            "enum": ["Board", "Dowel", "Wedge", "L-Bracket", "Tapered Leg", "Frustum Board"]
+            "enum": ["Board", "Dowel", "Wedge", "L-Bracket", "Tapered Leg", "Frustum Board", "Pyramid Frustum"]
           },
 
           "id": {
@@ -131,11 +131,19 @@
             "type": "number", "exclusiveMinimum": 0
           },
           "wTop": {
-            "description": "Top width in mm. Required for Frustum Board (may be 0 for a wedge-like collapse).",
+            "description": "Top width (along x) in mm. Required for Frustum Board and Pyramid Frustum (may be 0 for a wedge-like collapse / pointed apex).",
             "type": "number", "minimum": 0
           },
           "wBottom": {
-            "description": "Bottom width in mm. Required for Frustum Board (may be 0).",
+            "description": "Bottom width (along x) in mm. Required for Frustum Board and Pyramid Frustum (may be 0).",
+            "type": "number", "minimum": 0
+          },
+          "dTop": {
+            "description": "Top depth (along z) in mm. Required for Pyramid Frustum (may be 0).",
+            "type": "number", "minimum": 0
+          },
+          "dBottom": {
+            "description": "Bottom depth (along z) in mm. Required for Pyramid Frustum (may be 0).",
             "type": "number", "minimum": 0
           },
 
@@ -169,7 +177,7 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["Board", "Dowel", "Wedge", "L-Bracket", "Tapered Leg", "Frustum Board"]
+                      "enum": ["Board", "Dowel", "Wedge", "L-Bracket", "Tapered Leg", "Frustum Board", "Pyramid Frustum"]
                     },
                     "px": { "type": "number" },
                     "py": { "type": "number" },
@@ -184,7 +192,9 @@
                     "rTop": { "type": "number", "exclusiveMinimum": 0 },
                     "rBottom": { "type": "number", "exclusiveMinimum": 0 },
                     "wTop": { "type": "number", "minimum": 0 },
-                    "wBottom": { "type": "number", "minimum": 0 }
+                    "wBottom": { "type": "number", "minimum": 0 },
+                    "dTop": { "type": "number", "minimum": 0 },
+                    "dBottom": { "type": "number", "minimum": 0 }
                   }
                 }
               }

--- a/woodtemplates.schema.json
+++ b/woodtemplates.schema.json
@@ -23,7 +23,7 @@
       "type": {
         "description": "Piece shape. Must match one of the fixed English identifiers used in the app.",
         "type": "string",
-        "enum": ["Board", "Dowel", "Wedge", "L-Bracket", "Tapered Leg", "Frustum Board"]
+        "enum": ["Board", "Dowel", "Wedge", "L-Bracket", "Tapered Leg", "Frustum Board", "Pyramid Frustum"]
       },
 
       "price": {
@@ -57,11 +57,19 @@
         "type": "number", "exclusiveMinimum": 0
       },
       "wTop": {
-        "description": "Top width in mm. Required for Frustum Board.",
+        "description": "Top width (along x) in mm. Required for Frustum Board and Pyramid Frustum.",
         "type": "number", "minimum": 0
       },
       "wBottom": {
-        "description": "Bottom width in mm. Required for Frustum Board.",
+        "description": "Bottom width (along x) in mm. Required for Frustum Board and Pyramid Frustum.",
+        "type": "number", "minimum": 0
+      },
+      "dTop": {
+        "description": "Top depth (along z) in mm. Required for Pyramid Frustum.",
+        "type": "number", "minimum": 0
+      },
+      "dBottom": {
+        "description": "Bottom depth (along z) in mm. Required for Pyramid Frustum.",
         "type": "number", "minimum": 0
       }
     },
@@ -90,6 +98,10 @@
       {
         "if": { "properties": { "type": { "const": "Frustum Board" } } },
         "then": { "required": ["wTop", "wBottom", "h", "d"] }
+      },
+      {
+        "if": { "properties": { "type": { "const": "Pyramid Frustum" } } },
+        "then": { "required": ["wTop", "dTop", "wBottom", "dBottom", "h"] }
       }
     ]
   },


### PR DESCRIPTION
Closes #20. **Stacked on top of #27** (which is stacked on #26).

## Summary
- New \`Pyramid Frustum\` primitive: 4-sided frustum, both top and bottom faces are independent rectangles centered on y. Setting \`wTop = dTop = 0\` collapses the top to a point (true pyramid); same for the bottom.
- Parameters: \`wTop\`, \`dTop\`, \`wBottom\`, \`dBottom\`, \`h\`. Hand-built BufferGeometry (\`pyramidFrustumGeometry\`) — 8 vertices, 12 triangles, same topology as the Frustum Board.
- Wired through every type-branching code path (factory, rebuild, serialize/restore, templates, panel, CSV, sizes, schemas).
- Two built-in templates:
  - \`tpl.pyramidRoof\` — 100×100 → 40×40, H 60 (e.g. lantern roof)
  - \`tpl.pyramid\` — 100×100 → 0×0, H 80 (true pyramid)
- en + de translations including new field labels (\`D Top\` / \`D Bot\` / \`T oben\` / \`T unten\`).

## Test plan
- [ ] \`+ Add → Pyramid Frustum → Default\` renders as a frustum (40×40 top, 100×100 bottom).
- [ ] Edit \`W Top\` and \`D Top\` to 0 — collapses to a point cleanly (no normal artefacts).
- [ ] Add \`tpl.pyramidRoof\` template — single mesh, replaces what previously needed 4 wedges.
- [ ] Save & reload — geometry round-trips.
- [ ] Cut a Dowel hole into the pyramid frustum, save, reload — declarative csgOps replay still works.
- [ ] DE language: type label "Pyramidenstumpf", field labels "T oben/T unten" appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)