### PR TITLE
CI Stage 2: JS syntax check (#34)

### DIFF
--- a/.github/workflows/js-syntax.yml
+++ b/.github/workflows/js-syntax.yml
@@ -1,0 +1,70 @@
+name: JS syntax
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+
+      - name: Extract inline <script> blocks from index.html
+        id: extract
+        run: |
+          mkdir -p .ci-tmp
+          # Pull every block strictly between a bare "<script>" line and the next "</script>".
+          # External <script src="...">...</script> tags are skipped because their opening
+          # tag is not a bare "<script>" on its own.
+          awk '
+            /^<script>[[:space:]]*$/ { in_block = 1; n++; out = ".ci-tmp/inline_" n ".js"; next }
+            in_block && /<\/script>/ { in_block = 0; next }
+            in_block { print > out }
+          ' index.html
+
+          count=$(ls -1 .ci-tmp/inline_*.js 2>/dev/null | wc -l)
+          if [ "$count" -eq 0 ]; then
+            echo "::error::No inline <script> blocks found in index.html — extraction regex may be stale."
+            exit 1
+          fi
+          echo "Extracted $count inline script block(s):"
+          wc -l .ci-tmp/inline_*.js
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: Syntax-check each block with node --check
+        run: |
+          fail=0
+          echo "## JS syntax check" > "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          for f in .ci-tmp/inline_*.js; do
+            echo "::group::$f"
+            if out=$(node --check "$f" 2>&1); then
+              echo "OK"
+              lines=$(wc -l < "$f")
+              echo "- :white_check_mark: \`$f\` (${lines} lines)" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "$out"
+              {
+                echo "- :x: \`$f\`"
+                echo ""
+                echo '  ```'
+                echo "$out" | sed 's/^/  /'
+                echo '  ```'
+              } >> "$GITHUB_STEP_SUMMARY"
+              fail=1
+            fi
+            echo "::endgroup::"
+          done
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$fail" -eq 0 ]; then
+            echo "**All inline scripts parsed successfully.** :tada:" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "**One or more inline scripts have syntax errors.**" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          exit $fail

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,12 @@ A browser-based 3D woodworking modeler — a single self-contained `index.html` 
 
 No build step and no local toolchain. Open `index.html` directly in a browser to run. All HTML, CSS, and JavaScript live in a single file.
 
-CI runs JSON-schema validation on every push and pull request via `.github/workflows/schema.yml` — `examples/*.woodmodel.json` and `examples/*.woodtemplates.json` are validated against the repo's schemas using `ajv-cli`. The accompanying `package.json` is **CI-only**: it exists so the GitHub Actions runner can `npm install ajv-cli`. Do not assume Node is available locally — keep tooling that needs Node confined to CI.
+CI runs two checks on every push to `main` and on pull requests:
+
+- `.github/workflows/schema.yml` — validates `examples/*.woodmodel.json` and `examples/*.woodtemplates.json` against the repo's schemas using `ajv-cli`.
+- `.github/workflows/js-syntax.yml` — extracts the inline `<script>` blocks from `index.html` (any line that is exactly `<script>` opens a block; the next `</script>` closes it) and runs `node --check` on each. Catches unbalanced brackets, stray commas, and broken string literals before the file gets opened in a browser. **Keep the bare `<script>` and `</script>` lines in `index.html` on their own lines** — the awk extractor depends on it.
+
+The accompanying `package.json` is **CI-only**: it exists so the GitHub Actions runner can `npm install ajv-cli`. Do not assume Node is available locally — keep tooling that needs Node confined to CI.
 
 When you change `woodmodel.schema.json` or `woodtemplates.schema.json`, also update or add an example file in `examples/` so the CI catches schema drift.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 3D Wooden Modeler
 
-[![Schema validation](https://github.com/urfin78/3d-wooden-modeler/actions/workflows/schema.yml/badge.svg?branch=main)](https://github.com/urfin78/3d-wooden-modeler/actions/workflows/schema.yml)
+[![Schema validation](https://github.com/urfin78/3d-wooden-modeler/actions/workflows/schema.yml/badge.svg?branch=main)](https://github.com/urfin78/3d-wooden-modeler/actions/workflows/schema.yml) [![JS syntax](https://github.com/urfin78/3d-wooden-modeler/actions/workflows/js-syntax.yml/badge.svg?branch=main)](https://github.com/urfin78/3d-wooden-modeler/actions/workflows/js-syntax.yml)
 
 > This project was fully created using [Claude Code](https://claude.ai/claude-code) by Anthropic.
 
@@ -58,7 +58,12 @@ Load [`examples/stool.woodmodel.json`](examples/stool.woodmodel.json) via **Load
 
 ## CI
 
-GitHub Actions validates example files in `examples/` against `woodmodel.schema.json` and `woodtemplates.schema.json` on every push and pull request (`ajv-cli`). The `package.json` at the repo root exists only for this CI step — the app itself has no build dependencies.
+Two GitHub Actions workflows run on every push to `main` and on pull requests:
+
+- **Schema validation** — example files in `examples/` are validated against `woodmodel.schema.json` and `woodtemplates.schema.json` (`ajv-cli`).
+- **JS syntax** — the inline `<script>` block in `index.html` is extracted and parsed with `node --check` so unbalanced brackets, stray commas, or broken string literals fail before they ever reach a browser.
+
+The `package.json` at the repo root exists only for the schema CI step — the app itself has no build dependencies.
 
 ## License
 


### PR DESCRIPTION
Second step of #34. Adds a `node --check` syntax check on the inline `<script>` block in `index.html`.

## Summary
- New workflow `.github/workflows/js-syntax.yml` (push to main + pull_request).
- `awk` extracts every `<script>...</script>` block from `index.html` whose **opening tag is exactly `<script>` on its own line** — that skips the CDN `<script src=...>` line. Each block lands in `.ci-tmp/inline_N.js`.
- `node --check` parses each extracted block. Failures are surfaced both in the workflow log and as a checklist with the error inline in the run's Summary tab.
- Documented in CLAUDE.md (with the constraint that the bare `<script>` / `</script>` lines must stay on their own lines for the extractor to work) and added a status badge to README.

## Why this catches things Stage 1 doesn't
Stage 1 validates JSON structure. Stage 2 catches code-level breakage in `index.html` — unbalanced brackets, stray commas, broken string literals — without launching a browser. It's still **only syntax**, not semantics; type errors and missing globals (`THREE`, `document`) still need a browser test (Stage 3).

## Test plan
- [ ] CI run on this PR is green.
- [ ] On a throwaway branch, introduce a syntax error in `index.html` (e.g. delete a closing brace) → CI run fails with the line number from `node --check`. (Then revert.)
- [ ] If the inline script grows to multiple `<script>` blocks, each one shows up as its own entry in the Summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)