### PR TITLE
Fix: delete multi-selected pieces

### DIFF
--- a/index.html
+++ b/index.html
@@ -4513,6 +4513,22 @@ window.addEventListener('load', function() {
             updateGrid();
             return;
         }
+        if (multiSelected.size > 0) {
+            pushUndo();
+            multiSelected.forEach(function(m) {
+                var i = pieces.indexOf(m);
+                if (i !== -1) pieces.splice(i, 1);
+                removeLabel(m);
+                if (m.parent) m.parent.remove(m);
+                m.geometry.dispose();
+                m.material.dispose();
+            });
+            multiSelected.clear();
+            selectedPiece = null;
+            selectPiece(null);
+            updateGrid();
+            return;
+        }
         if (!selectedPiece) return;
         pushUndo();
         var idx = pieces.indexOf(selectedPiece);


### PR DESCRIPTION
## Summary
- `deleteSelected()` ignored the `multiSelected` Set, so Delete / trash icon did nothing when multiple pieces were Ctrl+clicked.
- Added a multi-select branch: one `pushUndo()`, iterate the Set, dispose geometry/material, clear the Set, then `selectPiece(null)` + `updateGrid()`.

Closes #38

## Test plan
- [x] Add 3+ pieces, Ctrl+click to multi-select, press Delete → all removed
- [x] Same flow via trash icon in floating action bar
- [x] Undo restores all deleted pieces in one step
- [x] Single-select delete and group delete still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)